### PR TITLE
Add week-status API endpoint

### DIFF
--- a/backend/internal/api/handlers/entries.go
+++ b/backend/internal/api/handlers/entries.go
@@ -76,6 +76,56 @@ func firstMondayOfFY(financialYear int) time.Time {
 	return jul1.AddDate(0, 0, 1-dow)
 }
 
+// GetWeekCompletionStatus returns the count of entries per week for a user in
+// a given financial year, limited to weeks up to and including the current week.
+//
+// Query params:
+//   - financial_year (optional): defaults to current FY
+func (h *Handler) GetWeekCompletionStatus(w http.ResponseWriter, r *http.Request) {
+	userID, ok := pathUserID(r)
+	if !ok {
+		respondError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	user, err := h.Store.GetUserByID(r.Context(), userID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not retrieve user")
+		return
+	}
+	if user == nil {
+		respondError(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	today := time.Now().UTC()
+
+	financialYear, hasFY := queryInt(r, "financial_year")
+	if !hasFY {
+		financialYear = model.FinancialYear(today)
+	}
+
+	results, err := h.Store.GetWeekCompletionStatus(r.Context(), userID, financialYear, today)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not retrieve week status")
+		return
+	}
+
+	type weekStatusResponse struct {
+		WeekStart string `json:"week_start"`
+		Count     int    `json:"count"`
+	}
+
+	resp := make([]weekStatusResponse, len(results))
+	for i, ws := range results {
+		resp[i] = weekStatusResponse{
+			WeekStart: ws.WeekStart.Format("2006-01-02"),
+			Count:     ws.Count,
+		}
+	}
+	respondJSON(w, resp)
+}
+
 // entryRequest is the JSON shape accepted when upserting entries.
 type entryRequest struct {
 	EntryDate string        `json:"entry_date"` // YYYY-MM-DD

--- a/backend/internal/api/handlers/entries_test.go
+++ b/backend/internal/api/handlers/entries_test.go
@@ -305,6 +305,122 @@ func TestGetFirstIncompleteWeek_InvalidFromDate(t *testing.T) {
 	}
 }
 
+func TestGetWeekCompletionStatus_ReturnsWeekCounts(t *testing.T) {
+	srv := newTestServer(t)
+	userID := mustCreateUser(t, srv, "alice")
+
+	// Seed a complete week in FY2026 (week of 2025-07-07)
+	entries := make([]map[string]any, 7)
+	for i := range 7 {
+		d := time.Date(2025, 7, 7+i, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+		entries[i] = map[string]any{"entry_date": d, "day_type": "office", "hours": 0}
+	}
+	do(t, srv, http.MethodPost, fmt.Sprintf("/api/users/%d/entries", userID), "alice", entries)
+
+	// Also seed a partial week (3 entries in week of 2025-07-14)
+	partial := []map[string]any{
+		{"entry_date": "2025-07-14", "day_type": "wfh", "hours": 8},
+		{"entry_date": "2025-07-15", "day_type": "office", "hours": 0},
+		{"entry_date": "2025-07-16", "day_type": "office", "hours": 0},
+	}
+	do(t, srv, http.MethodPost, fmt.Sprintf("/api/users/%d/entries", userID), "alice", partial)
+
+	resp := do(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/users/%d/entries/week-status?financial_year=2026", userID),
+		"alice", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body []map[string]any
+	decodeJSON(t, resp, &body)
+
+	// Result depends on whether today >= 2025-07-14. Since we can't control time
+	// in handler tests, we just verify the endpoint returns valid data.
+	if len(body) == 0 {
+		t.Fatal("expected at least 1 week status entry")
+	}
+
+	// First entry should be the complete week
+	if body[0]["week_start"] != "2025-07-07" {
+		t.Errorf("first week_start: got %v, want 2025-07-07", body[0]["week_start"])
+	}
+	if body[0]["count"] != float64(7) {
+		t.Errorf("first count: got %v, want 7", body[0]["count"])
+	}
+}
+
+func TestGetWeekCompletionStatus_DefaultsFY(t *testing.T) {
+	srv := newTestServer(t)
+	userID := mustCreateUser(t, srv, "alice")
+
+	// Seed an entry in the current FY
+	today := time.Now().UTC()
+	d := today.Format("2006-01-02")
+	do(t, srv, http.MethodPost,
+		fmt.Sprintf("/api/users/%d/entries", userID),
+		"alice",
+		[]map[string]any{{"entry_date": d, "day_type": "office", "hours": 0}},
+	)
+
+	// No financial_year param — should default to current FY
+	resp := do(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/users/%d/entries/week-status", userID),
+		"alice", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body []map[string]any
+	decodeJSON(t, resp, &body)
+	if len(body) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(body))
+	}
+	if body[0]["count"] != float64(1) {
+		t.Errorf("count: got %v, want 1", body[0]["count"])
+	}
+}
+
+func TestGetWeekCompletionStatus_UserNotFound(t *testing.T) {
+	srv := newTestServer(t)
+
+	resp := do(t, srv, http.MethodGet,
+		"/api/users/9999/entries/week-status?financial_year=2026",
+		"alice", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestGetWeekCompletionStatus_Unauthorised(t *testing.T) {
+	srv := newTestServer(t)
+
+	resp := do(t, srv, http.MethodGet,
+		"/api/users/1/entries/week-status?financial_year=2026",
+		"", nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestGetWeekCompletionStatus_EmptyFY(t *testing.T) {
+	srv := newTestServer(t)
+	userID := mustCreateUser(t, srv, "alice")
+
+	resp := do(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/users/%d/entries/week-status?financial_year=2026", userID),
+		"alice", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body []map[string]any
+	decodeJSON(t, resp, &body)
+	if len(body) != 0 {
+		t.Errorf("expected empty array, got %d entries", len(body))
+	}
+}
+
 func TestGetWeekEntries_Unauthorised(t *testing.T) {
 	srv := newTestServer(t)
 

--- a/backend/internal/api/handlers/routes.go
+++ b/backend/internal/api/handlers/routes.go
@@ -26,6 +26,7 @@ func NewRouter(h *Handler, authHeader string, frontendFS fs.FS, buildHash string
 	mux.Handle("GET /api/users/{id}/entries", auth(http.HandlerFunc(h.GetWeekEntries)))
 	mux.Handle("POST /api/users/{id}/entries", auth(http.HandlerFunc(h.UpsertWeekEntries)))
 	mux.Handle("GET /api/users/{id}/entries/first-incomplete-week", auth(http.HandlerFunc(h.GetFirstIncompleteWeek)))
+	mux.Handle("GET /api/users/{id}/entries/week-status", auth(http.HandlerFunc(h.GetWeekCompletionStatus)))
 
 	mux.Handle("GET /api/users/{id}/report", auth(http.HandlerFunc(h.GetReport)))
 	mux.Handle("GET /api/users/{id}/report/export", auth(http.HandlerFunc(h.ExportReport)))

--- a/backend/internal/db/entries.go
+++ b/backend/internal/db/entries.go
@@ -184,6 +184,48 @@ func mondayOf(d time.Time) time.Time {
 	return time.Date(d.Year(), d.Month(), d.Day()+offset, 0, 0, 0, 0, d.Location())
 }
 
+// WeekStatus represents the completion status of a single week.
+type WeekStatus struct {
+	WeekStart time.Time
+	Count     int
+}
+
+// GetWeekCompletionStatus returns the number of entries per week (grouped by
+// Monday) for the given user and financial year, limited to weeks up to and
+// including the week containing today. Only weeks with at least 1 entry are
+// returned, ordered by week_start ascending.
+func (s *Store) GetWeekCompletionStatus(ctx context.Context, userID int64, financialYear int, today time.Time) ([]WeekStatus, error) {
+	todayStr := today.Format("2006-01-02")
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT date(entry_date, '-' || ((strftime('%w', entry_date) + 6) % 7) || ' days') AS week_start,
+		       COUNT(*) AS count
+		FROM work_day_entries
+		WHERE user_id = ? AND financial_year = ?
+		  AND entry_date <= ?
+		GROUP BY week_start
+		ORDER BY week_start
+	`, userID, financialYear, todayStr)
+	if err != nil {
+		return nil, fmt.Errorf("get week completion status: %w", err)
+	}
+	defer rows.Close()
+
+	var results []WeekStatus
+	for rows.Next() {
+		var ws WeekStatus
+		var weekStartStr string
+		if err := rows.Scan(&weekStartStr, &ws.Count); err != nil {
+			return nil, fmt.Errorf("scan week status: %w", err)
+		}
+		ws.WeekStart, err = parseDate(weekStartStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse week_start: %w", err)
+		}
+		results = append(results, ws)
+	}
+	return results, rows.Err()
+}
+
 // scanEntries drains a *sql.Rows cursor into a slice of WorkDayEntry.
 func scanEntries(rows interface {
 	Next() bool

--- a/backend/internal/db/entries_test.go
+++ b/backend/internal/db/entries_test.go
@@ -344,6 +344,153 @@ func seedCompleteWeek(t *testing.T, s *db.Store, userID int64, weekMonday time.T
 	}
 }
 
+func TestGetWeekCompletionStatus_NoEntries(t *testing.T) {
+	s := newTestStore(t)
+	user := seedUser(t, s, "alice", "Alice Smith")
+
+	results, err := s.GetWeekCompletionStatus(context.Background(), user.ID, 2026, date(2025, 8, 1))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestGetWeekCompletionStatus_SingleCompleteWeek(t *testing.T) {
+	s := newTestStore(t)
+	user := seedUser(t, s, "alice", "Alice Smith")
+
+	weekStart := monday(2025, 7, 7)
+	seedCompleteWeek(t, s, user.ID, weekStart)
+
+	results, err := s.GetWeekCompletionStatus(context.Background(), user.ID, 2026, date(2025, 7, 13))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].WeekStart.Equal(weekStart) {
+		t.Errorf("week_start: got %v, want %v", results[0].WeekStart, weekStart)
+	}
+	if results[0].Count != 7 {
+		t.Errorf("count: got %d, want 7", results[0].Count)
+	}
+}
+
+func TestGetWeekCompletionStatus_PartialWeek(t *testing.T) {
+	s := newTestStore(t)
+	user := seedUser(t, s, "alice", "Alice Smith")
+
+	// Only 3 entries in a week
+	entries := []model.WorkDayEntry{
+		{UserID: user.ID, EntryDate: date(2025, 7, 7), DayType: model.DayTypeWFH, Hours: 8},
+		{UserID: user.ID, EntryDate: date(2025, 7, 8), DayType: model.DayTypeOffice},
+		{UserID: user.ID, EntryDate: date(2025, 7, 9), DayType: model.DayTypeOffice},
+	}
+	if err := s.UpsertEntries(context.Background(), entries); err != nil {
+		t.Fatalf("UpsertEntries: %v", err)
+	}
+
+	results, err := s.GetWeekCompletionStatus(context.Background(), user.ID, 2026, date(2025, 7, 13))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Count != 3 {
+		t.Errorf("count: got %d, want 3", results[0].Count)
+	}
+}
+
+func TestGetWeekCompletionStatus_ExcludesFutureWeeks(t *testing.T) {
+	s := newTestStore(t)
+	user := seedUser(t, s, "alice", "Alice Smith")
+
+	week1 := monday(2025, 7, 7)
+	week2 := monday(2025, 7, 14)
+	seedCompleteWeek(t, s, user.ID, week1)
+	seedCompleteWeek(t, s, user.ID, week2)
+
+	// today is in week1, so week2 entries should be excluded
+	results, err := s.GetWeekCompletionStatus(context.Background(), user.ID, 2026, date(2025, 7, 9))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (future week excluded), got %d", len(results))
+	}
+	if !results[0].WeekStart.Equal(week1) {
+		t.Errorf("week_start: got %v, want %v", results[0].WeekStart, week1)
+	}
+}
+
+func TestGetWeekCompletionStatus_MultipleWeeksOrdered(t *testing.T) {
+	s := newTestStore(t)
+	user := seedUser(t, s, "alice", "Alice Smith")
+
+	week1 := monday(2025, 7, 7)
+	week2 := monday(2025, 7, 14)
+	seedCompleteWeek(t, s, user.ID, week1)
+	seedCompleteWeek(t, s, user.ID, week2)
+
+	results, err := s.GetWeekCompletionStatus(context.Background(), user.ID, 2026, date(2025, 7, 20))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].WeekStart.Equal(week1) {
+		t.Errorf("first week_start: got %v, want %v", results[0].WeekStart, week1)
+	}
+	if !results[1].WeekStart.Equal(week2) {
+		t.Errorf("second week_start: got %v, want %v", results[1].WeekStart, week2)
+	}
+}
+
+func TestGetWeekCompletionStatus_IsolatedByUser(t *testing.T) {
+	s := newTestStore(t)
+	alice := seedUser(t, s, "alice", "Alice Smith")
+	bob := seedUser(t, s, "bob", "Bob Brown")
+
+	weekStart := monday(2025, 7, 7)
+	seedCompleteWeek(t, s, alice.ID, weekStart)
+
+	// Bob has no entries
+	results, err := s.GetWeekCompletionStatus(context.Background(), bob.ID, 2026, date(2025, 7, 13))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for bob, got %d", len(results))
+	}
+}
+
+func TestGetWeekCompletionStatus_OnlyGivenFY(t *testing.T) {
+	s := newTestStore(t)
+	user := seedUser(t, s, "alice", "Alice Smith")
+
+	// FY2025 entry (Jul 2024 - Jun 2025)
+	entries := []model.WorkDayEntry{
+		{UserID: user.ID, EntryDate: date(2024, 8, 5), DayType: model.DayTypeWFH, Hours: 8},
+	}
+	if err := s.UpsertEntries(context.Background(), entries); err != nil {
+		t.Fatalf("UpsertEntries: %v", err)
+	}
+
+	// Query FY2026 — should get nothing
+	results, err := s.GetWeekCompletionStatus(context.Background(), user.ID, 2026, date(2025, 8, 1))
+	if err != nil {
+		t.Fatalf("GetWeekCompletionStatus: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for wrong FY, got %d", len(results))
+	}
+}
+
 func TestGetFirstIncompleteWeek_NoEntries(t *testing.T) {
 	s := newTestStore(t)
 	user := seedUser(t, s, "alice", "Alice Smith")

--- a/docs/features.md
+++ b/docs/features.md
@@ -300,6 +300,7 @@ The server logs the username (from the forward-auth header, if present), `User-A
 | `GET` | `/api/users/{id}/entries?week_start=YYYY-MM-DD` | Returns entries for the 7-day window starting on `week_start` |
 | `POST` | `/api/users/{id}/entries` | Creates or updates a batch of day entries for the user |
 | `GET` | `/api/users/{id}/entries/first-incomplete-week` | Returns the Monday of the first week with < 7 entries |
+| `GET` | `/api/users/{id}/entries/week-status` | Returns completion counts per week for a financial year |
 
 #### `GET /api/users/{id}/entries/first-incomplete-week`
 
@@ -312,6 +313,19 @@ Response:
 - `{ "week_start": null }` — all weeks up to the current week are complete
 
 Implementation: fetches all entry dates for the user in the FY, then iterates week-by-week in Go to find the first with fewer than 7 entries.
+
+#### `GET /api/users/{id}/entries/week-status`
+
+Returns the number of entries per week for a user in a financial year, for use in week-picker UIs.
+
+Query params:
+- `financial_year` (optional) — defaults to current FY derived from today's date
+
+Response:
+- `[{"week_start": "2025-07-07", "count": 7}, {"week_start": "2025-07-14", "count": 3}, ...]`
+- Returns only weeks with at least 1 entry, up to and including the current week
+- Weeks are ordered by `week_start` ascending
+- `count` is 1–7 indicating how many days have entries in that week
 
 ### API (notifications)
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/users/{id}/entries/week-status?financial_year=X` endpoint returning entry counts per week (grouped by Monday) for a financial year
- Only includes weeks up to the current week, ordered ascending
- Defaults to current FY when `financial_year` param is omitted
- Phase 1 of #42 (week picker feature)

Closes #43

## Test plan
- [x] DB unit tests: no entries, complete week, partial week, future exclusion, ordering, user isolation, FY filtering
- [x] Handler tests: response shape, FY default, 404 user not found, 401 unauthorized, empty FY
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)