### PR TITLE
Add week picker bottom sheet UI

### DIFF
--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -528,3 +528,180 @@ func TestE2E_AutoAdvance_AfterSavingPastWeek(t *testing.T) {
 		t.Errorf("auto-advance: first row date got %q, want 2025-07-21", *firstDate)
 	}
 }
+
+// TestE2E_WeekPicker_OpensAndCloses verifies that tapping the week label
+// opens the week picker bottom sheet and that it can be closed.
+func TestE2E_WeekPicker_OpensAndCloses(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL + "?week=2025-08-04")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Click the week label to open the picker
+	page.MustEval(`() => document.getElementById('week-label').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === true`)
+
+	// Verify the dialog is visible
+	dialog := page.MustElement("#week-picker")
+	visible, err := dialog.Visible()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !visible {
+		t.Error("week-picker dialog should be visible after clicking week label")
+	}
+
+	// Close via the close button
+	page.MustEval(`() => document.getElementById('week-picker-close').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === false`)
+}
+
+// TestE2E_WeekPicker_SelectWeek verifies that tapping a week in the list
+// navigates to that week and closes the sheet.
+func TestE2E_WeekPicker_SelectWeek(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL + "?week=2025-08-04")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Open the week picker
+	page.MustEval(`() => document.getElementById('week-label').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === true`)
+
+	// Click the first week in the list (should be the first week of the FY)
+	page.MustEval(`() => document.querySelector('#week-list .week-list-item').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === false`)
+
+	// Verify the diary navigated to a different week
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+	rows := page.MustElements("#entry-tbody tr.day-row")
+	firstDate, err := rows[0].Attribute("data-date")
+	if err != nil || firstDate == nil {
+		t.Fatal("could not read data-date from first row")
+	}
+	// First week of FY2026 starts on 2025-07-07 (first Monday on or after July 1)
+	if *firstDate != "2025-07-07" {
+		t.Errorf("after selecting first week: got %q, want 2025-07-07", *firstDate)
+	}
+}
+
+// TestE2E_WeekPicker_CompletionIndicators verifies that weeks with 7 entries
+// show a green dot and incomplete weeks show a grey dot.
+func TestE2E_WeekPicker_CompletionIndicators(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+
+	u := testUsername(t, "alice")
+	userID := getUserID(t, serverURL, u)
+	// Seed one complete week
+	seedWeekEntries(t, serverURL, u, userID, "2025-07-07")
+
+	page.MustNavigate(serverURL + "?week=2025-08-04")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Open the week picker
+	page.MustEval(`() => document.getElementById('week-label').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === true`)
+
+	// The week list should contain items with completion indicators
+	waitFor(t, page, `() => document.querySelectorAll('#week-list .week-list-item').length > 0`)
+
+	// Check that the seeded week (2025-07-07) has a complete indicator
+	hasComplete := page.MustEval(`() => {
+		const items = document.querySelectorAll('#week-list .week-list-item');
+		for (const item of items) {
+			if (item.dataset.weekStart === '2025-07-07') {
+				return item.querySelector('.completion-dot').classList.contains('complete');
+			}
+		}
+		return false;
+	}`).Bool()
+	if !hasComplete {
+		t.Error("week 2025-07-07 should show complete indicator")
+	}
+
+	// Check that an unseeded week has an incomplete indicator
+	hasIncomplete := page.MustEval(`() => {
+		const items = document.querySelectorAll('#week-list .week-list-item');
+		for (const item of items) {
+			if (item.dataset.weekStart === '2025-07-14') {
+				return !item.querySelector('.completion-dot').classList.contains('complete');
+			}
+		}
+		return false;
+	}`).Bool()
+	if !hasIncomplete {
+		t.Error("week 2025-07-14 should show incomplete indicator")
+	}
+}
+
+// TestE2E_WeekPicker_LastWeekButton verifies the "Last week" quick-jump button.
+func TestE2E_WeekPicker_LastWeekButton(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+
+	// Start on a specific past week
+	page.MustNavigate(serverURL + "?week=2025-08-04")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Open the week picker and click "Last week"
+	page.MustEval(`() => document.getElementById('week-label').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === true`)
+
+	page.MustEval(`() => document.getElementById('jump-last-week').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === false`)
+
+	// The diary should now show the previous week (relative to today)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Just verify it navigated away from 2025-08-04
+	rows := page.MustElements("#entry-tbody tr.day-row")
+	firstDate, err := rows[0].Attribute("data-date")
+	if err != nil || firstDate == nil {
+		t.Fatal("could not read data-date from first row")
+	}
+	if *firstDate == "2025-08-04" {
+		t.Error("last week button should navigate away from current week")
+	}
+}
+
+// TestE2E_WeekPicker_CurrentWeekHighlighted verifies that the currently-viewed
+// week is highlighted in the list.
+func TestE2E_WeekPicker_CurrentWeekHighlighted(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL + "?week=2025-08-04")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Open the week picker
+	page.MustEval(`() => document.getElementById('week-label').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === true`)
+	waitFor(t, page, `() => document.querySelectorAll('#week-list .week-list-item').length > 0`)
+
+	// The week 2025-08-04 should be highlighted
+	isHighlighted := page.MustEval(`() => {
+		const items = document.querySelectorAll('#week-list .week-list-item');
+		for (const item of items) {
+			if (item.dataset.weekStart === '2025-08-04') {
+				return item.classList.contains('current-week');
+			}
+		}
+		return false;
+	}`).Bool()
+	if !isHighlighted {
+		t.Error("week 2025-08-04 should be highlighted as current week")
+	}
+}
+
+// TestE2E_WeekPicker_ChevronVisible verifies that the week label has a chevron indicator.
+func TestE2E_WeekPicker_ChevronVisible(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL + "?week=2025-08-04")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	label := page.MustElement("#week-label").MustText()
+	if !strings.Contains(label, "\u25BE") {
+		t.Errorf("week label should contain chevron (▾), got %q", label)
+	}
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -180,6 +180,29 @@ At install time the SW pre-caches bare asset URLs (`/js/app.js`, etc.). The fetc
   - 🟢 **"Week submitted"** — all 7 entries are present for the displayed week
   - The indicator is updated on every `loadWeek()` call using the entry count returned by the existing `getEntries` API — no additional request is needed
 
+#### Week Picker
+
+Tapping the week label (e.g. "12 May – 18 May ▾") opens a **bottom sheet dialog** that allows quick navigation to any week in the current financial year.
+
+**Contents:**
+- **Header** with a close button (×)
+- **Quick-jump buttons:**
+  - **Last week** — navigates to the most recently completed Mon–Sun week
+  - **First incomplete** — navigates to the earliest week with fewer than 7 saved entries (uses the existing `first-incomplete-week` API)
+- **Scrollable week list** showing every week from the first Monday on or after July 1 of the current FY up to the most recently completed week:
+  - Each item displays the week's date range (e.g. "7 Jul – 13 Jul 2025")
+  - A completion dot indicates status: green (●) for complete (7 entries), grey (○) for incomplete
+  - The current week is highlighted with a distinct background
+  - Tapping a week item navigates to that week and closes the dialog
+
+**Completion data** is fetched from `GET /api/users/{id}/entries/week-status?financial_year={fy}` when the picker opens. The dialog auto-scrolls to the current week on open.
+
+**Responsive behaviour:**
+- **Mobile (<600px):** anchored to the bottom of the viewport with rounded top corners (bottom sheet pattern)
+- **Desktop (≥600px):** centred on screen with a max width of 480px and full border radius
+
+The dialog is opened with `showModal()` and closed via the close button, backdrop click, or selecting a week.
+
 #### Smart Initial Load
 
 On app load (without a `?week=` query parameter), instead of always showing the current week, the app navigates to the **oldest week in the current financial year that has fewer than 7 entries saved**. If all weeks up to and including the current week are complete, the app falls back to the current week.

--- a/frontend/css/app.css
+++ b/frontend/css/app.css
@@ -124,6 +124,125 @@
   text-decoration: underline;
 }
 
+/* ── Week label (tappable) ─────────────────────────────────────────────────── */
+#week-label {
+  cursor: pointer;
+  user-select: none;
+}
+
+#week-label:hover {
+  color: var(--pico-primary, #1095c1);
+}
+
+/* ── Bottom sheet (week picker) ───────────────────────────────────────────── */
+dialog.bottom-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 12px 12px 0 0;
+  max-height: 70vh;
+  width: 100%;
+  max-width: 100%;
+  background: var(--pico-card-background-color, #fff);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
+}
+
+dialog.bottom-sheet[open] {
+  display: flex;
+  flex-direction: column;
+}
+
+dialog.bottom-sheet::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.bottom-sheet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1rem 0.5rem;
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.bottom-sheet-header .close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  margin: 0;
+  line-height: 1;
+  width: auto;
+  color: var(--pico-muted-color);
+}
+
+.bottom-sheet-actions {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.bottom-sheet-actions button {
+  flex: 1;
+  margin: 0;
+  padding: 0.5rem;
+}
+
+.bottom-sheet-list {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 1rem 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.week-list-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.5rem;
+  min-height: 44px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--pico-muted-border-color, #ddd);
+}
+
+.week-list-item:hover {
+  background: var(--pico-card-background-color, #f5f5f5);
+}
+
+.week-list-item.current-week {
+  background: var(--pico-primary-focus, rgba(16, 149, 193, 0.1));
+  font-weight: bold;
+}
+
+.completion-dot {
+  font-size: 0.75rem;
+  color: var(--pico-muted-color, #999);
+}
+
+.completion-dot.complete {
+  color: var(--pico-color-jade-550, #2d8a4e);
+}
+
+/* ── Desktop: center the bottom sheet ─────────────────────────────────────── */
+@media (min-width: 600px) {
+  dialog.bottom-sheet {
+    bottom: auto;
+    top: 50%;
+    left: 50%;
+    right: auto;
+    transform: translate(-50%, -50%);
+    max-width: 480px;
+    border-radius: 12px;
+    max-height: 70vh;
+  }
+}
+
 /* ── Notes toggle button (visible on mobile only) ──────────────────────────── */
 .notes-toggle {
   display: none;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,17 @@
         <strong id="week-label"></strong>
         <button id="next-week" class="secondary outline">Next &#8594;</button>
       </div>
+      <dialog id="week-picker" class="bottom-sheet">
+        <div class="bottom-sheet-header">
+          <span>Jump to week</span>
+          <button id="week-picker-close" class="close-btn" aria-label="Close">&times;</button>
+        </div>
+        <div class="bottom-sheet-actions">
+          <button id="jump-last-week">Last week</button>
+          <button id="jump-first-incomplete">First incomplete</button>
+        </div>
+        <div class="bottom-sheet-list" id="week-list"></div>
+      </dialog>
       <div class="week-status-bar">
         <span id="week-status" class="week-status"></span>
       </div>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -168,6 +168,10 @@ const api = {
     }
   },
 
+  getWeekStatus(userId, financialYear) {
+    return fetchJSON(`/api/users/${userId}/entries/week-status?financial_year=${financialYear}`);
+  },
+
   async logClientError(report) {
     try {
       // Use sendBeacon for fire-and-forget reliability; this endpoint has no auth.

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -179,6 +179,16 @@ function bindEvents() {
   on('next-week',    'click', () => { weekStart = addDays(weekStart,  7); loadWeek(); });
   on('save-entries', 'click', saveWeek);
 
+  on('week-label',        'click', openWeekPicker);
+  on('week-picker-close', 'click', closeWeekPicker);
+  on('jump-last-week',    'click', jumpLastWeek);
+  on('jump-first-incomplete', 'click', jumpFirstIncomplete);
+
+  // Close on backdrop click
+  document.getElementById('week-picker').addEventListener('click', e => {
+    if (e.target === e.currentTarget) closeWeekPicker();
+  });
+
   on('fy-select',   'change', e => { reportFY = parseInt(e.target.value, 10); loadReport(); });
   on('export-csv',  'click',  () => { window.location.href = api.exportURL(selectedUserId, reportFY); });
   on('print-pdf',   'click',  printReport);
@@ -227,7 +237,7 @@ function showView(v) {
 async function loadWeek({ keepStatus = false } = {}) {
   const ws = formatDate(weekStart);
   document.getElementById('week-label').textContent =
-    `${fmtLabel(ws)} — ${fmtLabel(formatDate(addDays(weekStart, 6)))}`;
+    `${fmtLabel(ws)} — ${fmtLabel(formatDate(addDays(weekStart, 6)))} \u25BE`;
 
   const entries = await api.getEntries(selectedUserId, ws).catch(() => []);
   const byDate  = Object.fromEntries(entries.map(e => [e.entry_date, e]));
@@ -389,6 +399,94 @@ function renderWeekStatus(count) {
     el.textContent = '🔴 Week not submitted';
     el.className = 'week-status not-submitted';
   }
+}
+
+// ── Week Picker ───────────────────────────────────────────────────────────
+async function openWeekPicker() {
+  const dialog = document.getElementById('week-picker');
+  const listEl = document.getElementById('week-list');
+
+  // Determine weeks in current FY up to the most recent fully-passed week
+  const fy = currentFY();
+  const fyStart = new Date(fy - 1, 6, 1); // July 1
+  const firstMonday = getMonday(fyStart);
+  // If firstMonday is before July 1, advance to the next week
+  const fyFirstMonday = firstMonday < fyStart ? addDays(firstMonday, 7) : firstMonday;
+
+  // Last week = most recently completed week (Sunday has passed)
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const thisMonday = getMonday(today);
+  const lastCompletedMonday = addDays(thisMonday, -7);
+
+  // Build list of all past weeks in this FY
+  const weeks = [];
+  let mon = new Date(fyFirstMonday);
+  while (mon <= lastCompletedMonday) {
+    weeks.push(new Date(mon));
+    mon = addDays(mon, 7);
+  }
+
+  // Fetch completion data
+  let statusMap = {};
+  try {
+    const statuses = await api.getWeekStatus(selectedUserId, fy);
+    statuses.forEach(s => { statusMap[s.week_start] = s.count; });
+  } catch (_) {}
+
+  const currentWeekStr = formatDate(weekStart);
+
+  listEl.innerHTML = weeks.map(w => {
+    const ws = formatDate(w);
+    const sun = formatDate(addDays(w, 6));
+    const count = statusMap[ws] || 0;
+    const isComplete = count >= 7;
+    const isCurrent = ws === currentWeekStr;
+    return `<div class="week-list-item${isCurrent ? ' current-week' : ''}" data-week-start="${ws}">
+      <span class="completion-dot${isComplete ? ' complete' : ''}">${isComplete ? '●' : '○'}</span>
+      <span>${fmtLabel(ws)} — ${fmtLabel(sun)}</span>
+    </div>`;
+  }).join('');
+
+  // Add click handlers to week items
+  listEl.querySelectorAll('.week-list-item').forEach(item => {
+    item.addEventListener('click', () => {
+      weekStart = getMonday(new Date(item.dataset.weekStart + 'T00:00:00'));
+      closeWeekPicker();
+      loadWeek();
+    });
+  });
+
+  dialog.showModal();
+
+  // Scroll to the current week
+  const currentItem = listEl.querySelector('.current-week');
+  if (currentItem) {
+    currentItem.scrollIntoView({ block: 'center', behavior: 'instant' });
+  }
+}
+
+function closeWeekPicker() {
+  document.getElementById('week-picker').close();
+}
+
+function jumpLastWeek() {
+  const thisMonday = getMonday(new Date());
+  weekStart = addDays(thisMonday, -7);
+  closeWeekPicker();
+  loadWeek();
+}
+
+async function jumpFirstIncomplete() {
+  try {
+    const fy = currentFY();
+    const data = await api.getFirstIncompleteWeek(selectedUserId, fy, null);
+    if (data.week_start) {
+      weekStart = getMonday(new Date(data.week_start + 'T00:00:00'));
+    }
+  } catch (_) {}
+  closeWeekPicker();
+  loadWeek();
 }
 
 // ── Settings ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a bottom sheet dialog triggered by tapping the week label (▾) for quick week navigation
- Includes "Last week" and "First incomplete" quick-jump buttons
- Scrollable week list with green/grey completion dots and current-week highlighting
- Fetches completion data from the week-status API endpoint added in #43
- 6 new e2e tests covering all week picker interactions
- Documentation updated in docs/features.md

Closes #44

## Test plan
- [x] All 20 e2e tests pass (14 existing + 6 new)
- [ ] Manually verify week label is clickable and opens the bottom sheet
- [ ] Verify "Last week" and "First incomplete" buttons navigate correctly
- [ ] Verify completion dots reflect saved/unsaved weeks
- [ ] Verify dialog closes on backdrop click, close button, and week selection
- [ ] Verify responsive layout (mobile: bottom sheet, desktop: centered dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)