### PR TITLE
Add manual user creation from UI (#49)

### DIFF
--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -871,12 +871,16 @@ func TestE2E_AddUser_CreatesAndSelectsUser(t *testing.T) {
 	page.MustNavigate(serverURL)
 	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
 
+	// Remember how many options exist before adding
+	initialCount := page.MustEval(`() => document.getElementById('user-select').options.length`).Int()
+
 	// Click the add user button
 	page.MustElement("#add-user-btn").MustClick()
 	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === true`)
 
-	// Fill in the form
-	page.MustElement("#add-user-username").MustInput("bob")
+	// Fill in the form — use test-unique username to avoid conflicts in shared DB
+	uniqueUser := testUsername(t, "bob") + "_new"
+	page.MustElement("#add-user-username").MustInput(uniqueUser)
 	page.MustElement("#add-user-display-name").MustInput("Bob Smith")
 
 	// Submit
@@ -884,10 +888,10 @@ func TestE2E_AddUser_CreatesAndSelectsUser(t *testing.T) {
 	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === false`)
 
 	// Verify the new user appears in the dropdown and is selected
-	waitFor(t, page, `() => {
+	waitFor(t, page, fmt.Sprintf(`() => {
 		const sel = document.getElementById('user-select');
-		return sel.options.length === 2 && sel.options[sel.selectedIndex].text === 'Bob Smith';
-	}`)
+		return sel.options.length === %d && sel.options[sel.selectedIndex].text === 'Bob Smith';
+	}`, initialCount+1))
 }
 
 // TestE2E_AddUser_DuplicateShowsError verifies that trying to create a user
@@ -898,11 +902,13 @@ func TestE2E_AddUser_DuplicateShowsError(t *testing.T) {
 	page.MustNavigate(serverURL)
 	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
 
-	// "alice" already exists (auto-created by /api/me)
+	// The auto-created user's username (varies by test environment)
+	existingUser := testUsername(t, "alice")
+
 	page.MustElement("#add-user-btn").MustClick()
 	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === true`)
 
-	page.MustElement("#add-user-username").MustInput("alice")
+	page.MustElement("#add-user-username").MustInput(existingUser)
 	page.MustElement("#add-user-display-name").MustInput("Alice Again")
 	page.MustElement("#add-user-submit").MustClick()
 
@@ -924,16 +930,19 @@ func TestE2E_AddUser_CancelClosesDialog(t *testing.T) {
 	page.MustNavigate(serverURL)
 	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
 
+	// Remember option count before opening dialog
+	initialCount := page.MustEval(`() => document.getElementById('user-select').options.length`).Int()
+
 	page.MustElement("#add-user-btn").MustClick()
 	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === true`)
 
 	page.MustElement("#add-user-cancel").MustClick()
 	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === false`)
 
-	// Only the initial user should be in the dropdown
+	// Dropdown should be unchanged after cancel
 	optionCount := page.MustEval(`() => document.getElementById('user-select').options.length`).Int()
-	if optionCount != 1 {
-		t.Errorf("expected 1 user in dropdown, got %d", optionCount)
+	if optionCount != initialCount {
+		t.Errorf("expected %d users in dropdown after cancel, got %d", initialCount, optionCount)
 	}
 }
 

--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -862,6 +862,81 @@ func TestE2E_WeekPicker_LoadingState(t *testing.T) {
 	page.MustEval(`() => { if (window._testOrigFetch) { window.fetch = window._testOrigFetch; delete window._testOrigFetch; } }`)
 }
 
+// TestE2E_AddUser_CreatesAndSelectsUser verifies that opening the add user
+// dialog, filling in the form, and submitting creates a new user that appears
+// in the dropdown and is automatically selected.
+func TestE2E_AddUser_CreatesAndSelectsUser(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Click the add user button
+	page.MustElement("#add-user-btn").MustClick()
+	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === true`)
+
+	// Fill in the form
+	page.MustElement("#add-user-username").MustInput("bob")
+	page.MustElement("#add-user-display-name").MustInput("Bob Smith")
+
+	// Submit
+	page.MustElement("#add-user-submit").MustClick()
+	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === false`)
+
+	// Verify the new user appears in the dropdown and is selected
+	waitFor(t, page, `() => {
+		const sel = document.getElementById('user-select');
+		return sel.options.length === 2 && sel.options[sel.selectedIndex].text === 'Bob Smith';
+	}`)
+}
+
+// TestE2E_AddUser_DuplicateShowsError verifies that trying to create a user
+// with an existing username shows an error message in the dialog.
+func TestE2E_AddUser_DuplicateShowsError(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// "alice" already exists (auto-created by /api/me)
+	page.MustElement("#add-user-btn").MustClick()
+	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === true`)
+
+	page.MustElement("#add-user-username").MustInput("alice")
+	page.MustElement("#add-user-display-name").MustInput("Alice Again")
+	page.MustElement("#add-user-submit").MustClick()
+
+	// The dialog should still be open with an error message
+	waitFor(t, page, `() => document.getElementById('add-user-error').textContent.includes('already exists')`)
+
+	// Dialog should still be open
+	isOpen := page.MustEval(`() => document.getElementById('add-user-dialog').open`).Bool()
+	if !isOpen {
+		t.Error("dialog should remain open on error")
+	}
+}
+
+// TestE2E_AddUser_CancelClosesDialog verifies that the cancel button closes
+// the dialog without creating a user.
+func TestE2E_AddUser_CancelClosesDialog(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	page.MustElement("#add-user-btn").MustClick()
+	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === true`)
+
+	page.MustElement("#add-user-cancel").MustClick()
+	waitFor(t, page, `() => document.getElementById('add-user-dialog').open === false`)
+
+	// Only the initial user should be in the dropdown
+	optionCount := page.MustEval(`() => document.getElementById('user-select').options.length`).Int()
+	if optionCount != 1 {
+		t.Errorf("expected 1 user in dropdown, got %d", optionCount)
+	}
+}
+
 // TestE2E_WeekPicker_ErrorState verifies that an error message is shown when
 // the week-status API fails, but quick-jump buttons still work.
 func TestE2E_WeekPicker_ErrorState(t *testing.T) {

--- a/backend/e2e/server_docker_test.go
+++ b/backend/e2e/server_docker_test.go
@@ -136,7 +136,7 @@ func newPage(t *testing.T, _ string) (*rod.Browser, *rod.Page) {
 	browser := rod.New().ControlURL(controlURL).MustConnect()
 	t.Cleanup(func() { browser.MustClose() })
 
-	page := browser.MustPage("")
+	page := browser.MustPage("").Timeout(15 * time.Second)
 	cleanup, err := page.SetExtraHeaders([]string{dockerAuthHeader, t.Name()})
 	if err != nil {
 		t.Fatalf("set extra headers: %v", err)

--- a/backend/e2e/server_local_test.go
+++ b/backend/e2e/server_local_test.go
@@ -5,6 +5,7 @@ package e2e_test
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"ato-wfh-diary/frontend"
 	"ato-wfh-diary/internal/api/handlers"
@@ -56,7 +57,7 @@ func newPage(t *testing.T, username string) (*rod.Browser, *rod.Page) {
 	browser := rod.New().ControlURL(controlURL).MustConnect()
 	t.Cleanup(func() { browser.MustClose() })
 
-	page := browser.MustPage("")
+	page := browser.MustPage("").Timeout(15 * time.Second)
 	cleanup, err := page.SetExtraHeaders([]string{localAuthHeader, username})
 	if err != nil {
 		t.Fatalf("set extra headers: %v", err)

--- a/backend/internal/api/handlers/routes.go
+++ b/backend/internal/api/handlers/routes.go
@@ -19,6 +19,7 @@ func NewRouter(h *Handler, authHeader string, frontendFS fs.FS, buildHash string
 	auth := middleware.ForwardAuth(authHeader)
 
 	mux.Handle("GET /api/users", auth(http.HandlerFunc(h.GetUsers)))
+	mux.Handle("POST /api/users", auth(http.HandlerFunc(h.CreateUser)))
 	mux.Handle("GET /api/me", auth(http.HandlerFunc(h.GetMe)))
 	mux.Handle("GET /api/me/profile", auth(http.HandlerFunc(h.GetProfile)))
 	mux.Handle("PUT /api/me/profile", auth(http.HandlerFunc(h.UpsertProfile)))

--- a/backend/internal/api/handlers/users.go
+++ b/backend/internal/api/handlers/users.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"ato-wfh-diary/internal/api/middleware"
 	"ato-wfh-diary/internal/model"
+	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // GetUsers returns all users, ordered by display name.
@@ -18,6 +20,46 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 		users = []model.User{}
 	}
 	respondJSON(w, users)
+}
+
+// CreateUser manually creates a new user. Returns 201 on success, 409 if the
+// username already exists, or 400 if the request body is invalid.
+func (h *Handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Username    string `json:"username"`
+		DisplayName string `json:"display_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	req.Username = strings.TrimSpace(req.Username)
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+
+	if req.Username == "" || req.DisplayName == "" {
+		respondError(w, http.StatusBadRequest, "username and display_name are required")
+		return
+	}
+
+	existing, err := h.Store.GetUserByUsername(r.Context(), req.Username)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not check user")
+		return
+	}
+	if existing != nil {
+		respondError(w, http.StatusConflict, "username already exists")
+		return
+	}
+
+	user, err := h.Store.UpsertUser(r.Context(), req.Username, req.DisplayName)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not create user")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(user)
 }
 
 // GetMe returns the currently authenticated user, creating their record on

--- a/backend/internal/api/handlers/users_test.go
+++ b/backend/internal/api/handlers/users_test.go
@@ -103,3 +103,98 @@ func TestGetMe_Unauthorised(t *testing.T) {
 		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusUnauthorized)
 	}
 }
+
+func TestCreateUser_Success(t *testing.T) {
+	srv := newTestServer(t)
+
+	// Authenticate as alice so we can make requests.
+	mustCreateUser(t, srv, "alice")
+
+	resp := do(t, srv, http.MethodPost, "/api/users", "alice", map[string]string{
+		"username":     "bob",
+		"display_name": "Bob Smith",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	var user struct {
+		ID          int64  `json:"id"`
+		Username    string `json:"username"`
+		DisplayName string `json:"display_name"`
+	}
+	decodeJSON(t, resp, &user)
+
+	if user.ID == 0 {
+		t.Error("expected non-zero ID")
+	}
+	if user.Username != "bob" {
+		t.Errorf("username: got %q, want %q", user.Username, "bob")
+	}
+	if user.DisplayName != "Bob Smith" {
+		t.Errorf("display_name: got %q, want %q", user.DisplayName, "Bob Smith")
+	}
+
+	// Verify the user appears in GET /api/users.
+	listResp := do(t, srv, http.MethodGet, "/api/users", "alice", nil)
+	var users []map[string]any
+	decodeJSON(t, listResp, &users)
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+}
+
+func TestCreateUser_Conflict(t *testing.T) {
+	srv := newTestServer(t)
+
+	mustCreateUser(t, srv, "alice")
+
+	// Try to create a user with the same username.
+	resp := do(t, srv, http.MethodPost, "/api/users", "alice", map[string]string{
+		"username":     "alice",
+		"display_name": "Alice Again",
+	})
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestCreateUser_EmptyUsername(t *testing.T) {
+	srv := newTestServer(t)
+
+	mustCreateUser(t, srv, "alice")
+
+	resp := do(t, srv, http.MethodPost, "/api/users", "alice", map[string]string{
+		"username":     "",
+		"display_name": "No Username",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestCreateUser_EmptyDisplayName(t *testing.T) {
+	srv := newTestServer(t)
+
+	mustCreateUser(t, srv, "alice")
+
+	resp := do(t, srv, http.MethodPost, "/api/users", "alice", map[string]string{
+		"username":     "bob",
+		"display_name": "",
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestCreateUser_Unauthorised(t *testing.T) {
+	srv := newTestServer(t)
+
+	resp := do(t, srv, http.MethodPost, "/api/users", "", map[string]string{
+		"username":     "bob",
+		"display_name": "Bob",
+	})
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,15 @@ When the auth session expires the reverse proxy redirects API requests to an ext
 - Either user can **view and edit the other's entries**, as either may be responsible for completing the family's tax return
 - There is no concept of private entries — all entries are visible to both users
 
+### Manual User Creation
+
+Users can be manually created from the UI via the **+** button next to the user selector dropdown. This allows tracking WFH hours for a family member who hasn't logged in yet.
+
+- Clicking the **+** button opens a dialog with username and display name fields
+- On submission, `POST /api/users` creates the user and they appear in the dropdown, automatically selected
+- If the username already exists, a **409 Conflict** error is shown in the dialog
+- When a manually-created user eventually logs in via Forward Auth, `GetOrCreateUser` finds their existing record — no conflict
+
 ## Weekly Time Entry
 
 - Time is entered **one week at a time**
@@ -334,6 +343,14 @@ On any error it POSTs to `POST /api/debug/client-error` using `navigator.sendBea
 The server logs the username (from the forward-auth header, if present), `User-Agent`, and all payload fields. The endpoint does **not** require authentication so it can be reached even when auth is failing.
 
 > **Note:** if the reverse proxy applies authentication to all `/api/` paths, `/api/debug/client-error` may need to be whitelisted to receive unauthenticated error reports.
+
+### API (users)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/users` | Returns all users ordered by display name |
+| `POST` | `/api/users` | Creates a new user; returns 201 on success, 409 if username exists, 400 if fields are empty |
+| `GET` | `/api/me` | Returns the authenticated user, creating on first login |
 
 ### API (entries)
 

--- a/frontend/css/app.css
+++ b/frontend/css/app.css
@@ -13,6 +13,38 @@
   margin: 0;
 }
 
+/* ── Add user button ──────────────────────────────────────────────────────── */
+#add-user-btn {
+  width: auto;
+  margin: 0;
+  padding: 0.25rem 0.65rem;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+/* ── Add user dialog ─────────────────────────────────────────────────────── */
+#add-user-dialog article {
+  margin: 0;
+}
+
+#add-user-dialog article header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#add-user-dialog article header .close-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  margin: 0;
+  line-height: 1;
+  width: auto;
+  color: var(--pico-muted-color);
+}
+
 /* ── Week navigation ───────────────────────────────────────────────────────── */
 .week-nav {
   display: flex;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,28 @@
     <div class="user-bar">
       <label for="user-select">Viewing:</label>
       <select id="user-select"></select>
+      <button id="add-user-btn" class="outline secondary" aria-label="Add user" title="Add user">+</button>
     </div>
+
+    <dialog id="add-user-dialog">
+      <article>
+        <header>
+          <strong>Add User</strong>
+          <button id="add-user-close" class="close-btn" aria-label="Close">&times;</button>
+        </header>
+        <form id="add-user-form">
+          <label for="new-username">Username</label>
+          <input type="text" id="new-username" required>
+          <label for="new-display-name">Display Name</label>
+          <input type="text" id="new-display-name" required>
+          <span id="add-user-error" class="save-msg error"></span>
+          <footer>
+            <button type="submit">Create</button>
+            <button type="button" id="add-user-cancel" class="secondary">Cancel</button>
+          </footer>
+        </form>
+      </article>
+    </dialog>
 
     <!-- Diary view -->
     <section id="view-diary">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,13 +39,13 @@
           <button id="add-user-close" class="close-btn" aria-label="Close">&times;</button>
         </header>
         <form id="add-user-form">
-          <label for="new-username">Username</label>
-          <input type="text" id="new-username" required>
-          <label for="new-display-name">Display Name</label>
-          <input type="text" id="new-display-name" required>
+          <label for="add-user-username">Username</label>
+          <input type="text" id="add-user-username" required>
+          <label for="add-user-display-name">Display Name</label>
+          <input type="text" id="add-user-display-name" required>
           <span id="add-user-error" class="save-msg error"></span>
           <footer>
-            <button type="submit">Create</button>
+            <button type="submit" id="add-user-submit">Create</button>
             <button type="button" id="add-user-cancel" class="secondary">Cancel</button>
           </footer>
         </form>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -53,6 +53,21 @@ const api = {
     return fetchJSON('/api/users');
   },
 
+  async createUser(username, displayName) {
+    const r = await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, display_name: displayName }),
+      redirect: 'manual',
+    });
+    if (isAuthFailure(r)) return new Promise(() => {});
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new Error(body.error || `HTTP ${r.status}`);
+    }
+    return r.json();
+  },
+
   getEntries(userId, weekStart) {
     return fetchJSON(`/api/users/${userId}/entries?week_start=${weekStart}`);
   },

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -207,6 +207,11 @@ function bindEvents() {
   });
   on('save-notif', 'click', saveNotificationPrefs);
   on('test-notif', 'click', sendTestNotification);
+  on('add-user-btn',    'click', openAddUserDialog);
+  on('add-user-close',  'click', closeAddUserDialog);
+  on('add-user-cancel', 'click', closeAddUserDialog);
+  on('add-user-form',   'submit', handleAddUser);
+
   on('notif-install-btn', 'click', async () => {
     if (!installPrompt) return;
     installPrompt.prompt();
@@ -225,6 +230,39 @@ function bindEvents() {
       hoursEl.value = userProfile.default_hours;
     }
   });
+}
+
+// ── Add User Dialog ───────────────────────────────────────────────────────
+function openAddUserDialog() {
+  document.getElementById('new-username').value = '';
+  document.getElementById('new-display-name').value = '';
+  document.getElementById('add-user-error').textContent = '';
+  document.getElementById('add-user-dialog').showModal();
+}
+
+function closeAddUserDialog() {
+  document.getElementById('add-user-dialog').close();
+}
+
+async function handleAddUser(e) {
+  e.preventDefault();
+  const username = document.getElementById('new-username').value.trim();
+  const displayName = document.getElementById('new-display-name').value.trim();
+  const errorEl = document.getElementById('add-user-error');
+  errorEl.textContent = '';
+
+  try {
+    const user = await api.createUser(username, displayName);
+    allUsers.push(user);
+    populateUserSelect();
+    document.getElementById('user-select').value = user.id;
+    selectedUserId = user.id;
+    closeAddUserDialog();
+    if (view === 'diary') loadWeek();
+    else if (view === 'report') loadReport();
+  } catch (err) {
+    errorEl.textContent = err.message;
+  }
 }
 
 // ── Views ──────────────────────────────────────────────────────────────────

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -234,8 +234,8 @@ function bindEvents() {
 
 // ── Add User Dialog ───────────────────────────────────────────────────────
 function openAddUserDialog() {
-  document.getElementById('new-username').value = '';
-  document.getElementById('new-display-name').value = '';
+  document.getElementById('add-user-username').value = '';
+  document.getElementById('add-user-display-name').value = '';
   document.getElementById('add-user-error').textContent = '';
   document.getElementById('add-user-dialog').showModal();
 }
@@ -246,8 +246,8 @@ function closeAddUserDialog() {
 
 async function handleAddUser(e) {
   e.preventDefault();
-  const username = document.getElementById('new-username').value.trim();
-  const displayName = document.getElementById('new-display-name').value.trim();
+  const username = document.getElementById('add-user-username').value.trim();
+  const displayName = document.getElementById('add-user-display-name').value.trim();
   const errorEl = document.getElementById('add-user-error');
   errorEl.textContent = '';
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/users` endpoint with validation (required fields, duplicate detection)
- Frontend dialog triggered by `+` button next to user dropdown — creates user, selects them, reloads view
- 5 unit tests and 3 E2E tests covering success, conflict, and cancel flows
- Documentation updated in `docs/features.md`

Closes #49

## Test plan
- [x] Unit tests pass (5 new handler tests)
- [x] E2E tests compile (3 new UI tests)
- [ ] Manual: click `+`, fill form, verify user appears in dropdown
- [ ] Manual: try duplicate username, verify error message
- [ ] Manual: click Cancel, verify dialog closes without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)