### PR TITLE
Add per-user profile API endpoints (#52)

### DIFF
--- a/backend/internal/api/handlers/profiles.go
+++ b/backend/internal/api/handlers/profiles.go
@@ -44,6 +44,98 @@ func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, profile)
 }
 
+// GetUserProfile returns the profile for the user identified by {id} in the URL path.
+func (h *Handler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
+	userID, ok := pathUserID(r)
+	if !ok {
+		respondError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	user, err := h.Store.GetUserByID(r.Context(), userID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not retrieve user")
+		return
+	}
+	if user == nil {
+		respondError(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	profile, err := h.Store.GetProfile(r.Context(), user.ID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not retrieve profile")
+		return
+	}
+	if profile == nil {
+		respondError(w, http.StatusNotFound, "profile not configured")
+		return
+	}
+	respondJSON(w, profile)
+}
+
+// UpsertUserProfile creates or updates the profile for the user identified by {id} in the URL path.
+func (h *Handler) UpsertUserProfile(w http.ResponseWriter, r *http.Request) {
+	userID, ok := pathUserID(r)
+	if !ok {
+		respondError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	user, err := h.Store.GetUserByID(r.Context(), userID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not retrieve user")
+		return
+	}
+	if user == nil {
+		respondError(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	var req profileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.DefaultHours <= 0 || req.DefaultHours > 24 {
+		respondError(w, http.StatusBadRequest, "default_hours must be between 0 and 24")
+		return
+	}
+
+	dayTypes := []model.DayType{req.MonType, req.TueType, req.WedType, req.ThuType, req.FriType, req.SatType, req.SunType}
+	dayNames := []string{"mon_type", "tue_type", "wed_type", "thu_type", "fri_type", "sat_type", "sun_type"}
+	for i, dt := range dayTypes {
+		if !dt.IsValid() {
+			respondError(w, http.StatusBadRequest, dayNames[i]+" has invalid day type")
+			return
+		}
+	}
+
+	profile := model.UserProfile{
+		UserID:       user.ID,
+		DefaultHours: req.DefaultHours,
+		MonType:      req.MonType,
+		TueType:      req.TueType,
+		WedType:      req.WedType,
+		ThuType:      req.ThuType,
+		FriType:      req.FriType,
+		SatType:      req.SatType,
+		SunType:      req.SunType,
+	}
+	if err := h.Store.UpsertProfile(r.Context(), profile); err != nil {
+		respondError(w, http.StatusInternalServerError, "could not save profile")
+		return
+	}
+
+	saved, err := h.Store.GetProfile(r.Context(), user.ID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "could not retrieve saved profile")
+		return
+	}
+	respondJSON(w, saved)
+}
+
 // UpsertProfile creates or updates the current user's profile.
 func (h *Handler) UpsertProfile(w http.ResponseWriter, r *http.Request) {
 	username := middleware.UsernameFromContext(r.Context())

--- a/backend/internal/api/handlers/profiles_test.go
+++ b/backend/internal/api/handlers/profiles_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -182,6 +183,230 @@ func TestPutProfile_InvalidHours(t *testing.T) {
 	resp := do(t, srv, http.MethodPut, "/api/me/profile", "alice", profile)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+// --- /api/users/{id}/profile endpoint tests ---
+
+func TestGetUserProfile_Found(t *testing.T) {
+	srv := newTestServer(t)
+	aliceID := mustCreateUser(t, srv, "alice")
+
+	// Create a profile for alice via /api/me/profile
+	profile := map[string]any{
+		"default_hours": 7.5,
+		"mon_type":      "wfh",
+		"tue_type":      "wfh",
+		"wed_type":      "office",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	do(t, srv, http.MethodPut, "/api/me/profile", "alice", profile)
+
+	// Fetch via /api/users/{id}/profile (bob fetching alice's profile)
+	mustCreateUser(t, srv, "bob")
+	resp := do(t, srv, http.MethodGet, fmt.Sprintf("/api/users/%d/profile", aliceID), "bob", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var got map[string]any
+	decodeJSON(t, resp, &got)
+	if got["default_hours"] != 7.5 {
+		t.Errorf("default_hours: got %v, want 7.5", got["default_hours"])
+	}
+	if got["mon_type"] != "wfh" {
+		t.Errorf("mon_type: got %v, want wfh", got["mon_type"])
+	}
+	if got["wed_type"] != "office" {
+		t.Errorf("wed_type: got %v, want office", got["wed_type"])
+	}
+}
+
+func TestGetUserProfile_NotFound(t *testing.T) {
+	srv := newTestServer(t)
+	aliceID := mustCreateUser(t, srv, "alice")
+
+	// Alice has no profile yet
+	resp := do(t, srv, http.MethodGet, fmt.Sprintf("/api/users/%d/profile", aliceID), "alice", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestGetUserProfile_InvalidID(t *testing.T) {
+	srv := newTestServer(t)
+	mustCreateUser(t, srv, "alice")
+
+	resp := do(t, srv, http.MethodGet, "/api/users/abc/profile", "alice", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestGetUserProfile_NonexistentUser(t *testing.T) {
+	srv := newTestServer(t)
+	mustCreateUser(t, srv, "alice")
+
+	resp := do(t, srv, http.MethodGet, "/api/users/9999/profile", "alice", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestPutUserProfile_Create(t *testing.T) {
+	srv := newTestServer(t)
+	aliceID := mustCreateUser(t, srv, "alice")
+	mustCreateUser(t, srv, "bob")
+
+	profile := map[string]any{
+		"default_hours": 8.0,
+		"mon_type":      "wfh",
+		"tue_type":      "wfh",
+		"wed_type":      "wfh",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	// Bob creates alice's profile
+	resp := do(t, srv, http.MethodPut, fmt.Sprintf("/api/users/%d/profile", aliceID), "bob", profile)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Verify via GET
+	getResp := do(t, srv, http.MethodGet, fmt.Sprintf("/api/users/%d/profile", aliceID), "bob", nil)
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status: got %d, want %d", getResp.StatusCode, http.StatusOK)
+	}
+	var got map[string]any
+	decodeJSON(t, getResp, &got)
+	if got["default_hours"] != 8.0 {
+		t.Errorf("default_hours: got %v, want 8.0", got["default_hours"])
+	}
+}
+
+func TestPutUserProfile_Update(t *testing.T) {
+	srv := newTestServer(t)
+	aliceID := mustCreateUser(t, srv, "alice")
+
+	first := map[string]any{
+		"default_hours": 8.0,
+		"mon_type":      "wfh",
+		"tue_type":      "wfh",
+		"wed_type":      "wfh",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	do(t, srv, http.MethodPut, fmt.Sprintf("/api/users/%d/profile", aliceID), "alice", first)
+
+	second := map[string]any{
+		"default_hours": 6.0,
+		"mon_type":      "wfh",
+		"tue_type":      "office",
+		"wed_type":      "wfh",
+		"thu_type":      "office",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	resp := do(t, srv, http.MethodPut, fmt.Sprintf("/api/users/%d/profile", aliceID), "alice", second)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var got map[string]any
+	decodeJSON(t, resp, &got)
+	if got["default_hours"] != 6.0 {
+		t.Errorf("default_hours: got %v, want 6.0", got["default_hours"])
+	}
+	if got["tue_type"] != "office" {
+		t.Errorf("tue_type: got %v, want office", got["tue_type"])
+	}
+}
+
+func TestPutUserProfile_InvalidDayType(t *testing.T) {
+	srv := newTestServer(t)
+	aliceID := mustCreateUser(t, srv, "alice")
+
+	profile := map[string]any{
+		"default_hours": 8.0,
+		"mon_type":      "nap",
+		"tue_type":      "wfh",
+		"wed_type":      "wfh",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	resp := do(t, srv, http.MethodPut, fmt.Sprintf("/api/users/%d/profile", aliceID), "alice", profile)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestPutUserProfile_InvalidHours(t *testing.T) {
+	srv := newTestServer(t)
+	aliceID := mustCreateUser(t, srv, "alice")
+
+	profile := map[string]any{
+		"default_hours": -1.0,
+		"mon_type":      "wfh",
+		"tue_type":      "wfh",
+		"wed_type":      "wfh",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	resp := do(t, srv, http.MethodPut, fmt.Sprintf("/api/users/%d/profile", aliceID), "alice", profile)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestPutUserProfile_InvalidID(t *testing.T) {
+	srv := newTestServer(t)
+	mustCreateUser(t, srv, "alice")
+
+	profile := map[string]any{
+		"default_hours": 8.0,
+		"mon_type":      "wfh",
+		"tue_type":      "wfh",
+		"wed_type":      "wfh",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	resp := do(t, srv, http.MethodPut, "/api/users/abc/profile", "alice", profile)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestPutUserProfile_NonexistentUser(t *testing.T) {
+	srv := newTestServer(t)
+	mustCreateUser(t, srv, "alice")
+
+	profile := map[string]any{
+		"default_hours": 8.0,
+		"mon_type":      "wfh",
+		"tue_type":      "wfh",
+		"wed_type":      "wfh",
+		"thu_type":      "wfh",
+		"fri_type":      "wfh",
+		"sat_type":      "weekend",
+		"sun_type":      "weekend",
+	}
+	resp := do(t, srv, http.MethodPut, "/api/users/9999/profile", "alice", profile)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 

--- a/backend/internal/api/handlers/routes.go
+++ b/backend/internal/api/handlers/routes.go
@@ -24,6 +24,9 @@ func NewRouter(h *Handler, authHeader string, frontendFS fs.FS, buildHash string
 	mux.Handle("GET /api/me/profile", auth(http.HandlerFunc(h.GetProfile)))
 	mux.Handle("PUT /api/me/profile", auth(http.HandlerFunc(h.UpsertProfile)))
 
+	mux.Handle("GET /api/users/{id}/profile", auth(http.HandlerFunc(h.GetUserProfile)))
+	mux.Handle("PUT /api/users/{id}/profile", auth(http.HandlerFunc(h.UpsertUserProfile)))
+
 	mux.Handle("GET /api/users/{id}/entries", auth(http.HandlerFunc(h.GetWeekEntries)))
 	mux.Handle("POST /api/users/{id}/entries", auth(http.HandlerFunc(h.UpsertWeekEntries)))
 	mux.Handle("GET /api/users/{id}/entries/first-incomplete-week", auth(http.HandlerFunc(h.GetFirstIncompleteWeek)))

--- a/docs/features.md
+++ b/docs/features.md
@@ -72,6 +72,8 @@ Each user can optionally configure a profile via the **Settings** page. The prof
 
 - `GET /api/me/profile` — returns the current user's profile; 404 if not configured
 - `PUT /api/me/profile` — creates or updates the current user's profile
+- `GET /api/users/{id}/profile` — returns the specified user's profile; 404 if not configured or user doesn't exist
+- `PUT /api/users/{id}/profile` — creates or updates the specified user's profile; 404 if user doesn't exist
 
 ## Financial Year Reporting
 


### PR DESCRIPTION
## Summary
- Add `GET /api/users/{id}/profile` and `PUT /api/users/{id}/profile` endpoints so the frontend can fetch and update any user's profile, not just the logged-in user's
- Consistent with the existing shared-family-access model used by `/api/users/{id}/entries` and `/api/users/{id}/report`
- Existing `/api/me/profile` endpoints remain unchanged

## Test plan
- [x] 10 new unit tests covering: found/not-found profiles, invalid IDs, nonexistent users, create/update, validation errors (invalid day type, invalid hours)
- [x] Full test suite passes

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)