### PR TITLE
Fix PWA swallowing auth reauthentication redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,11 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
-      - name: Install Chromium
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends chromium-browser
+      # browser-actions/setup-chrome installs Chrome without snap and puts it on
+      # PATH; go-rod's launcher.LookPath() finds it. Avoids the flaky
+      # apt/snap-based chromium-browser install (intermittent snapcraft 408s).
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
 
       - name: Run E2E tests
         run: make test-e2e
@@ -50,8 +53,11 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
-      - name: Install Chromium
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends chromium-browser
+      # browser-actions/setup-chrome installs Chrome without snap and puts it on
+      # PATH; go-rod's launcher.LookPath() finds it. Avoids the flaky
+      # apt/snap-based chromium-browser install (intermittent snapcraft 408s).
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
 
       - name: Run E2E tests against Docker container
         run: make test-e2e-docker

--- a/backend/e2e/server_docker_test.go
+++ b/backend/e2e/server_docker_test.go
@@ -127,7 +127,11 @@ func newE2EServer(t *testing.T) string {
 func newPage(t *testing.T, _ string) (*rod.Browser, *rod.Page) {
 	t.Helper()
 
-	l := launcher.New().Headless(true)
+	// NoSandbox is required on hosts where Chrome's sandbox cannot initialise —
+	// e.g. GitHub's Ubuntu 24.04 runners, which restrict unprivileged user
+	// namespaces via AppArmor. rod only auto-adds it when it detects a
+	// container, which is not the case on a runner VM, so set it explicitly.
+	l := launcher.New().Headless(true).NoSandbox(true)
 	if path, ok := launcher.LookPath(); ok {
 		l = l.Bin(path)
 	}

--- a/backend/e2e/server_local_test.go
+++ b/backend/e2e/server_local_test.go
@@ -48,7 +48,11 @@ func newE2EServer(t *testing.T) string {
 func newPage(t *testing.T, username string) (*rod.Browser, *rod.Page) {
 	t.Helper()
 
-	l := launcher.New().Headless(true)
+	// NoSandbox is required on hosts where Chrome's sandbox cannot initialise —
+	// e.g. GitHub's Ubuntu 24.04 runners, which restrict unprivileged user
+	// namespaces via AppArmor. rod only auto-adds it when it detects a
+	// container, which is not the case on a runner VM, so set it explicitly.
+	l := launcher.New().Headless(true).NoSandbox(true)
 	if path, ok := launcher.LookPath(); ok {
 		l = l.Bin(path)
 	}

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,8 @@
 
 When the auth session expires the reverse proxy redirects API requests to an external login page (a different origin). All `fetch()` calls use `redirect: 'manual'` so the browser stops at the redirect and returns an `opaqueredirect` response rather than throwing a CORS error on iOS Safari. The app detects this condition (`response.type === 'opaqueredirect'`, or HTTP 401/403) and triggers a full-page navigation to the current URL — Traefik/Authelia intercepts the page request, redirects the user to the login screen, and returns them to the app after successful authentication.
 
+For this redirect to reach the proxy, the service worker must **not** serve the cached app shell in response to the navigation. The fetch handler therefore uses a network-first strategy for navigation requests (`request.mode === 'navigate'`); see [Service Worker caching strategy](#service-worker-caching-strategy). A cache-first navigation would short-circuit the request, swallow the reauthentication redirect, and leave the installed PWA stuck showing the shell with no data.
+
 ## User Access
 
 - Two users (a couple) share the application
@@ -174,6 +176,12 @@ const CACHE = 'wfh-diary-{{.BuildHash}}';
 This means every new deployment produces a different SW file (different bytes), causing the browser to detect an update, install the new SW, and delete the old versioned cache. The SW is served with `Cache-Control: no-cache` so the browser always checks for a new version.
 
 At install time the SW pre-caches bare asset URLs (`/js/app.js`, etc.). The fetch handler uses `{ ignoreSearch: true }` when looking up cache entries so that versioned URLs like `/js/app.js?v=abc123` are served from the cache without a round trip to the network.
+
+The fetch handler chooses a strategy per request:
+
+- **`/api/` requests** — always go to the network (the SW does not intercept them).
+- **Top-level navigations** (`request.mode === 'navigate'`) — **network-first**: the SW fetches from the network and only falls back to the cached `/` shell if the network is unreachable (offline). This ensures an expired-session redirect to the auth proxy is followed by the browser rather than being swallowed by the cached shell (see [Expired session handling](#expired-session-handling)).
+- **Static assets** (CSS, JS, icons, manifest) — **cache-first**: served from the cache when present, falling back to the network on a miss.
 
 ### Views
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -21,6 +21,19 @@ self.addEventListener('fetch', e => {
   // Always fetch API calls from the network
   if (new URL(e.request.url).pathname.startsWith('/api/')) return;
 
+  // Network-first for top-level navigations so that when the reverse-proxy auth
+  // session (Authelia) has expired, the proxy's redirect to the login page
+  // actually reaches the network instead of being short-circuited by the cached
+  // app shell. Serving the cached '/' here would swallow the reauthentication
+  // redirect, leaving the PWA stuck showing the shell with zero data. Fall back
+  // to the cached shell only when the network is unreachable (offline).
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      fetch(e.request).catch(() => caches.match('/', { ignoreSearch: true }))
+    );
+    return;
+  }
+
   e.respondWith(
     // ignoreSearch so versioned URLs like /js/app.js?v=abc123 match the
     // bare-URL entries stored in the cache at install time.


### PR DESCRIPTION
The service worker served all non-/api/ requests cache-first, including top-level navigations. When the Authelia session expired, the navigation that should reach the proxy (either a cold PWA launch or the full-page redirect triggered by an opaqueredirect API response) was answered from the cached app shell, so the login redirect never reached the network. The PWA reloaded the shell endlessly with zero data.

Use a network-first strategy for navigation requests so the proxy's redirect to the login page is followed by the browser, falling back to the cached shell only when offline. Static assets remain cache-first and /api/ requests are untouched.

Update docs/features.md (expired-session handling and SW caching strategy).