### PR TITLE
Pin the clock in E2E tests so CI survives the financial year rollover

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"ato-wfh-diary/frontend"
 	"ato-wfh-diary/internal/api/handlers"
+	"ato-wfh-diary/internal/clock"
 	"ato-wfh-diary/internal/db"
 	"ato-wfh-diary/internal/service"
 	"ato-wfh-diary/migrations"
@@ -35,6 +36,13 @@ func main() {
 	notifyBody := envOr("NOTIFICATION_BODY", "Time to log your hours for this week")
 	notifySchedulerInterval := envOr("NOTIFICATION_SCHEDULER_INTERVAL", "10m")
 	vapidSubject := envOr("VAPID_SUBJECT", "mailto:admin@example.com")
+
+	if today, pinned, err := clock.FixFromEnv(); err != nil {
+		log.Fatalf("invalid %s: %v", clock.TestTodayEnv, err)
+	} else if pinned {
+		log.Printf("WARNING: %s is set — the server believes today is %s. Never set this in production.",
+			clock.TestTodayEnv, today.Format("2006-01-02"))
+	}
 
 	schedulerInterval, err := time.ParseDuration(notifySchedulerInterval)
 	if err != nil {

--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -15,6 +15,50 @@ import (
 	"github.com/go-rod/rod/lib/proto"
 )
 
+// e2eToday is the date every E2E run pretends it is. The tests assert on
+// concrete dates in FY2026, which only hold while "today" sits inside that FY —
+// left on the real clock the whole suite breaks on 1 July, when the financial
+// year rolls over. Both the server (via internal/clock) and the browser (via
+// pinBrowserClock) are pinned to this date, so the suite is reproducible on any
+// day of any year.
+//
+// It must be a date comfortably inside FY2026 and far enough past the FY start
+// that the tests have several completed weeks to work with.
+const e2eToday = "2026-03-24"
+
+// pinBrowserClock makes the page's JS clock report the given YYYY-MM-DD date on
+// every subsequent navigation. The frontend derives the current financial year
+// and the "past weeks" list from new Date(), so pinning the server alone is not
+// enough.
+//
+// The shim keeps every other Date behaviour intact: only the zero-argument
+// constructor and Date.now() are redirected, so date parsing and arithmetic in
+// the app still work normally. Calling it again re-pins the page to a different
+// date — it stashes the genuine Date on first use, so each pin wraps the real
+// one rather than the previous shim.
+func pinBrowserClock(t *testing.T, page *rod.Page, today string) {
+	t.Helper()
+	// Midday UTC, matching clock.Fix on the server, so both agree on the
+	// calendar date regardless of the browser's timezone.
+	script := fmt.Sprintf(`(() => {
+		const RealDate = window.__realDate || Date;
+		window.__realDate = RealDate;
+		const fixed = new RealDate(%q + 'T12:00:00Z').getTime();
+		function PinnedDate(...args) {
+			return args.length === 0 ? new RealDate(fixed) : new RealDate(...args);
+		}
+		PinnedDate.prototype = RealDate.prototype;
+		PinnedDate.now   = () => fixed;
+		PinnedDate.parse = RealDate.parse;
+		PinnedDate.UTC   = RealDate.UTC;
+		window.Date = PinnedDate;
+	})()`, today)
+
+	if _, err := page.EvalOnNewDocument(script); err != nil {
+		t.Fatalf("pin browser clock to %s: %v", today, err)
+	}
+}
+
 // seedWeekEntries makes a direct API call to seed 7 entries for the given weekMonday (YYYY-MM-DD).
 func seedWeekEntries(t *testing.T, serverURL, username string, userID int64, weekMonday string) {
 	t.Helper()
@@ -579,16 +623,63 @@ func TestE2E_WeekPicker_SelectWeek(t *testing.T) {
 	page.MustEval(`() => document.querySelector('#week-list .week-list-item').click()`)
 	waitFor(t, page, `() => document.getElementById('week-picker').open === false`)
 
-	// Verify the diary navigated to a different week
-	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+	// Wait for the diary to actually re-render the newly selected week. Waiting
+	// on the row count alone races: seven rows are already on the page from the
+	// week we navigated in on, so the old rows can be read before the new week
+	// loads. Wait for the rows to belong to a different week instead.
+	waitFor(t, page, `() => {
+		const rows = document.querySelectorAll('#entry-tbody tr.day-row');
+		return rows.length === 7 && rows[0].dataset.date !== '2025-08-04';
+	}`)
+
 	rows := page.MustElements("#entry-tbody tr.day-row")
 	firstDate, err := rows[0].Attribute("data-date")
 	if err != nil || firstDate == nil {
 		t.Fatal("could not read data-date from first row")
 	}
-	// First week of FY2026 starts on 2025-07-07 (first Monday on or after July 1)
-	if *firstDate != "2025-07-07" {
-		t.Errorf("after selecting first week: got %q, want 2025-07-07", *firstDate)
+	// The FY's first week is the week containing 1 Jul 2025 (a Tuesday), so it
+	// starts on Mon 30 Jun 2025 — the same week smart init treats as first.
+	if *firstDate != "2025-06-30" {
+		t.Errorf("after selecting first week: got %q, want 2025-06-30", *firstDate)
+	}
+}
+
+// TestE2E_WeekPicker_EmptyAtFYRollover verifies that in the days right after
+// the financial year rolls over on 1 July — when the new FY has no completed
+// weeks to list yet — the picker says so instead of rendering a blank sheet.
+//
+// Only the browser clock is moved here: the week list is computed client-side
+// from new Date(), and the server is only asked for completion counts, so this
+// reproduces the rollover without disturbing the pinned server clock (which the
+// Docker container fixes process-wide and cannot vary per test).
+func TestE2E_WeekPicker_EmptyAtFYRollover(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+
+	// Fri 3 Jul 2026: FY2027 has begun, but its first week (Mon 29 Jun – Sun
+	// 5 Jul) is still running, so no week of the FY has completed yet.
+	pinBrowserClock(t, page, "2026-07-03")
+
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	page.MustEval(`() => document.getElementById('week-label').click()`)
+	waitFor(t, page, `() => document.getElementById('week-picker').open === true`)
+
+	waitFor(t, page, `() => document.querySelector('#week-list .week-list-empty') !== null`)
+
+	items := page.MustEval(`() => document.querySelectorAll('#week-list .week-list-item').length`).Int()
+	if items != 0 {
+		t.Errorf("week list at FY rollover: got %d items, want 0", items)
+	}
+
+	// The quick-jump buttons must keep working even with nothing to list.
+	visible, err := page.MustElement("#jump-last-week").Visible()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !visible {
+		t.Error("last-week quick jump should remain usable when the week list is empty")
 	}
 }
 

--- a/backend/e2e/server_docker_test.go
+++ b/backend/e2e/server_docker_test.go
@@ -141,6 +141,7 @@ func newPage(t *testing.T, _ string) (*rod.Browser, *rod.Page) {
 	t.Cleanup(func() { browser.MustClose() })
 
 	page := browser.MustPage("").Timeout(15 * time.Second)
+	pinBrowserClock(t, page, e2eToday)
 	cleanup, err := page.SetExtraHeaders([]string{dockerAuthHeader, t.Name()})
 	if err != nil {
 		t.Fatalf("set extra headers: %v", err)

--- a/backend/e2e/server_local_test.go
+++ b/backend/e2e/server_local_test.go
@@ -9,6 +9,7 @@ import (
 
 	"ato-wfh-diary/frontend"
 	"ato-wfh-diary/internal/api/handlers"
+	"ato-wfh-diary/internal/clock"
 	"ato-wfh-diary/internal/db"
 	"ato-wfh-diary/migrations"
 
@@ -29,6 +30,7 @@ func testUsername(_ *testing.T, fallback string) string { return fallback }
 // and the embedded frontend. Returns the server's base URL.
 func newE2EServer(t *testing.T) string {
 	t.Helper()
+	pinServerClock(t)
 	database, err := db.Open(":memory:", migrations.FS)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -42,6 +44,19 @@ func newE2EServer(t *testing.T) string {
 		database.Close()
 	})
 	return srv.URL
+}
+
+// pinServerClock makes the in-process server believe today is e2eToday. The
+// Docker harness does the same thing through the WFH_TEST_TODAY environment
+// variable, which the container's entrypoint reads at startup.
+func pinServerClock(t *testing.T) {
+	t.Helper()
+	today, err := time.Parse("2006-01-02", e2eToday)
+	if err != nil {
+		t.Fatalf("parse e2eToday: %v", err)
+	}
+	clock.Fix(today)
+	t.Cleanup(func() { clock.Now = time.Now })
 }
 
 // newPage launches a headless browser page pre-authenticated as username.
@@ -62,6 +77,7 @@ func newPage(t *testing.T, username string) (*rod.Browser, *rod.Page) {
 	t.Cleanup(func() { browser.MustClose() })
 
 	page := browser.MustPage("").Timeout(15 * time.Second)
+	pinBrowserClock(t, page, e2eToday)
 	cleanup, err := page.SetExtraHeaders([]string{localAuthHeader, username})
 	if err != nil {
 		t.Fatalf("set extra headers: %v", err)

--- a/backend/internal/api/handlers/entries.go
+++ b/backend/internal/api/handlers/entries.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"ato-wfh-diary/internal/clock"
 	"ato-wfh-diary/internal/model"
 	"encoding/json"
 	"fmt"
@@ -32,7 +33,7 @@ func (h *Handler) GetFirstIncompleteWeek(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	today := time.Now().UTC()
+	today := clock.Now().UTC()
 
 	financialYear, hasFY := queryInt(r, "financial_year")
 	if !hasFY {
@@ -98,7 +99,7 @@ func (h *Handler) GetWeekCompletionStatus(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	today := time.Now().UTC()
+	today := clock.Now().UTC()
 
 	financialYear, hasFY := queryInt(r, "financial_year")
 	if !hasFY {

--- a/backend/internal/clock/clock.go
+++ b/backend/internal/clock/clock.go
@@ -1,0 +1,45 @@
+// Package clock is the application's source of "today".
+//
+// Almost everything the app decides — which financial year is current, which
+// weeks are in the past, which week to open on — is derived from the current
+// date. Reading time.Now() directly at those call sites makes the behaviour
+// untestable: the E2E suite drives the real UI against real dates, so on
+// 1 July its expectations silently became wrong when the financial year rolled
+// over. Routing "today" through this package lets the E2E runs pin it.
+package clock
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// TestTodayEnv pins "today" to the given YYYY-MM-DD date when set. It is read
+// once at startup and is intended for E2E runs against the container image;
+// production deployments leave it unset.
+const TestTodayEnv = "WFH_TEST_TODAY"
+
+// Now returns the current time. Tests replace it to pin a fixed date.
+var Now = time.Now
+
+// Fix pins Now to midday UTC on the given date. Midday (rather than midnight)
+// keeps the pinned calendar date the same in every timezone the app runs in.
+func Fix(date time.Time) {
+	fixed := time.Date(date.Year(), date.Month(), date.Day(), 12, 0, 0, 0, time.UTC)
+	Now = func() time.Time { return fixed }
+}
+
+// FixFromEnv pins Now if TestTodayEnv is set. It reports whether the clock was
+// pinned, and errors if the variable is set but unparseable.
+func FixFromEnv() (time.Time, bool, error) {
+	v := os.Getenv(TestTodayEnv)
+	if v == "" {
+		return time.Time{}, false, nil
+	}
+	date, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("%s must be a YYYY-MM-DD date: %w", TestTodayEnv, err)
+	}
+	Fix(date)
+	return Now(), true, nil
+}

--- a/backend/internal/clock/clock_test.go
+++ b/backend/internal/clock/clock_test.go
@@ -1,0 +1,62 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFixPinsToMiddayUTC(t *testing.T) {
+	t.Cleanup(func() { Now = time.Now })
+
+	Fix(time.Date(2026, time.March, 24, 0, 0, 0, 0, time.UTC))
+
+	got := Now()
+	want := time.Date(2026, time.March, 24, 12, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("Now() = %v, want %v", got, want)
+	}
+
+	// Midday UTC keeps the calendar date intact for any offset within ±11h,
+	// which spans every timezone the app runs in (Australia/Melbourne is +11
+	// at its furthest, during daylight saving).
+	for _, offset := range []int{-11, 0, 10, 11} {
+		loc := time.FixedZone("test", offset*3600)
+		if d := Now().In(loc).Day(); d != 24 {
+			t.Errorf("pinned date at UTC%+d = day %d, want 24", offset, d)
+		}
+	}
+}
+
+func TestFixFromEnv(t *testing.T) {
+	t.Cleanup(func() { Now = time.Now })
+
+	t.Run("unset leaves the real clock alone", func(t *testing.T) {
+		_, pinned, err := FixFromEnv()
+		if err != nil || pinned {
+			t.Fatalf("FixFromEnv() = pinned %v, err %v; want pinned false, no error", pinned, err)
+		}
+	})
+
+	t.Run("valid date pins the clock", func(t *testing.T) {
+		t.Setenv(TestTodayEnv, "2026-03-24")
+
+		today, pinned, err := FixFromEnv()
+		if err != nil || !pinned {
+			t.Fatalf("FixFromEnv() = pinned %v, err %v; want pinned true, no error", pinned, err)
+		}
+		if got := today.Format("2006-01-02"); got != "2026-03-24" {
+			t.Errorf("pinned date = %s, want 2026-03-24", got)
+		}
+		if !Now().Equal(today) {
+			t.Errorf("Now() = %v, want %v", Now(), today)
+		}
+	})
+
+	t.Run("unparseable date is an error, not a silent fallback", func(t *testing.T) {
+		t.Setenv(TestTodayEnv, "24/03/2026")
+
+		if _, pinned, err := FixFromEnv(); err == nil || pinned {
+			t.Errorf("FixFromEnv() = pinned %v, err %v; want an error", pinned, err)
+		}
+	})
+}

--- a/backend/internal/service/report.go
+++ b/backend/internal/service/report.go
@@ -1,8 +1,8 @@
 package service
 
 import (
+	"ato-wfh-diary/internal/clock"
 	"ato-wfh-diary/internal/model"
-	"time"
 )
 
 // ReportSummary is the top-level result of a financial year WFH report.
@@ -33,12 +33,12 @@ func BuildReport(userID int64, financialYear int, entries []model.WorkDayEntry, 
 
 // CurrentFinancialYear returns the financial year that contains today's date.
 func CurrentFinancialYear() int {
-	return model.FinancialYear(time.Now())
+	return model.FinancialYear(clock.Now())
 }
 
 // LastFinancialYear returns the most recently completed financial year.
 func LastFinancialYear() int {
-	now := time.Now()
+	now := clock.Now()
 	fy := model.FinancialYear(now)
 	// If we're still in the first day of the new FY (1 Jul) the current FY has
 	// barely started — either way, "last FY" is always current FY minus one.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,3 +18,8 @@ services:
     environment:
       - DB_PATH=/data/wfh.db
       - FORWARD_AUTH_HEADER=X-Forwarded-User
+      # Pin the server's idea of "today" so the E2E suite's FY2026 date
+      # assertions hold on any day of any year. Must match e2eToday in
+      # backend/e2e/e2e_test.go, which pins the browser's clock to the same day.
+      # Test-only — never set this in a real deployment.
+      - WFH_TEST_TODAY=2026-03-24

--- a/docs/features.md
+++ b/docs/features.md
@@ -208,9 +208,10 @@ Tapping the week label (e.g. "12 May – 18 May ▾") opens a **bottom sheet dia
 - **Quick-jump buttons:**
   - **Last week** — navigates to the most recently completed Mon–Sun week
   - **First incomplete** — navigates to the earliest week with fewer than 7 saved entries (uses the existing `first-incomplete-week` API)
-- **Scrollable week list** showing every week from the first Monday on or after July 1 of the current FY up to the most recently completed week:
+- **Scrollable week list** showing every week of the current FY, from the week containing July 1 up to the most recently completed week:
   - Each item displays the week's date range (e.g. "7 Jul – 13 Jul 2025")
-  - A completion dot indicates status: green (●) for complete (7 entries), grey (○) for incomplete
+  - The FY's **first week is the week containing July 1**, even where that week begins in June (e.g. FY2026 starts Tue 1 Jul 2025, so its first week starts Mon 30 Jun 2025). That week's July days belong to the FY and must be filled in, and Smart Initial Load opens it, so the picker lists it too — the picker and the `first-incomplete-week` API agree on where the FY begins.
+  - A completion dot indicates status: green (●) for complete, grey (○) for incomplete. A week is complete when it has an entry for every day of the week that falls **inside the FY** — so the straddling first week needs only its July days (e.g. 6 for FY2026), matching the rule the backend applies.
   - The current week is highlighted with a distinct background
   - Tapping a week item navigates to that week and closes the dialog
 
@@ -240,6 +241,7 @@ The dialog is opened with `showModal()` and closed via the close button, backdro
 
 **Edge cases:**
 - If the current FY has just started with only one past week, the list displays correctly
+- Immediately after the FY rolls over on 1 July, the new FY may have no completed weeks at all. The list then shows "No completed weeks yet this financial year" rather than rendering empty. The quick-jump buttons remain functional.
 
 #### Smart Initial Load
 
@@ -418,3 +420,16 @@ make test-e2e
 ```
 
 E2E tests use the `e2e` build tag and are excluded from the standard `make test` run.
+
+#### Pinned clock
+
+The app's behaviour depends on the current date — which financial year is current, which weeks are in the past, which week to open on. The E2E tests assert on concrete FY2026 dates, so they only hold while "today" sits inside FY2026; left on the real system clock the whole suite would break on 1 July each year, when the Australian financial year rolls over.
+
+Both sides of the app are therefore pinned to a fixed date (`2026-03-24`) for E2E runs:
+
+- **Server:** all date-dependent code reads `internal/clock.Now()` rather than `time.Now()`. The in-process E2E server pins it directly; the Docker E2E container pins it via the `WFH_TEST_TODAY` environment variable (set in `docker-compose.test.yml`), which `main` reads at startup.
+- **Browser:** `pinBrowserClock` installs a `Date` shim before page scripts run, so `new Date()` and `Date.now()` report the same pinned date. Only the zero-argument constructor and `Date.now()` are redirected — parsing and date arithmetic behave normally.
+
+The pinned date is defined once as `e2eToday` in `backend/e2e/e2e_test.go` and must be kept in sync with `WFH_TEST_TODAY` in `docker-compose.test.yml`.
+
+`WFH_TEST_TODAY` is a **test-only** switch. It is unset in production; when it is set the server logs a loud startup warning.

--- a/frontend/css/app.css
+++ b/frontend/css/app.css
@@ -281,6 +281,7 @@ button.week-list-item.current-week {
 }
 
 .week-list-loading,
+.week-list-empty,
 .week-list-error {
   padding: 1.5rem;
   text-align: center;

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -35,6 +35,16 @@ const financialYear = d => d.getMonth() >= 6 ? d.getFullYear() + 1 : d.getFullYe
 const currentFY    = () => financialYear(new Date());
 const defaultFY    = () => currentFY() - 1;
 
+// requiredDays returns how many days of the week beginning on monday fall inside
+// the financial year beginning on fyStart. A week straddling 1 July only needs
+// its in-FY days filled in to count as complete, which is the same rule the
+// backend applies when it looks for the first incomplete week.
+const requiredDays = (monday, fyStart) => {
+  const from   = monday < fyStart ? fyStart : monday;
+  const sunday = addDays(monday, 6);
+  return Math.round((sunday - from) / 86400000) + 1;
+};
+
 function fmtLabel(dateStr) {
   return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-AU', {
     weekday: 'short', day: 'numeric', month: 'short',
@@ -467,9 +477,10 @@ async function openWeekPicker() {
   // Determine weeks in current FY up to the most recent fully-passed week
   const fy = currentFY();
   const fyStart = new Date(fy - 1, 6, 1); // July 1
-  const firstMonday = getMonday(fyStart);
-  // If firstMonday is before July 1, advance to the next week
-  const fyFirstMonday = firstMonday < fyStart ? addDays(firstMonday, 7) : firstMonday;
+  // The FY's first week is the one containing July 1, even where that week
+  // starts in June: its July days belong to the FY and must be filled in, and
+  // smart init will open it, so the picker has to list it too.
+  const fyFirstMonday = getMonday(fyStart);
 
   // Last week = most recently completed week (Sunday has passed)
   const today = new Date();
@@ -500,6 +511,10 @@ async function openWeekPicker() {
 
   if (fetchFailed) {
     listEl.innerHTML = '<div class="week-list-error">Could not load weeks</div>';
+  } else if (weeks.length === 0) {
+    // Between 1 July and the end of the FY's first week there is nothing to
+    // list yet. Say so — an empty sheet reads as a broken picker.
+    listEl.innerHTML = '<div class="week-list-empty">No completed weeks yet this financial year</div>';
   } else {
     const currentWeekStr = formatDate(weekStart);
 
@@ -507,7 +522,7 @@ async function openWeekPicker() {
       const ws = formatDate(w);
       const sun = formatDate(addDays(w, 6));
       const count = statusMap[ws] || 0;
-      const isComplete = count >= 7;
+      const isComplete = count >= requiredDays(w, fyStart);
       const isCurrent = ws === currentWeekStr;
       return `<button type="button" class="week-list-item${isCurrent ? ' current-week' : ''}" data-week-start="${ws}">
         <span class="completion-dot${isComplete ? ' complete' : ''}">${isComplete ? '●' : '○'}</span>


### PR DESCRIPTION
## What was actually broken

Nothing in [#63](https://github.com/acbgbca/ato-wfh-diary/pull/63) — no dependency update caused those failures. The E2E suite asserts on concrete FY2026 dates (`2025-07-07`, `2025-07-21`, …) but derived "today" from the real system clock on both sides of the app. When the Australian financial year rolled over on **1 July 2026**, the app correctly moved to FY2027 while the tests still demanded FY2026 weeks.

The failures reproduce identically on a clean `main` with zero dependency changes:

```
smart init: first row date got "2026-06-29", want 2025-07-21
after selecting first week: got "2026-07-06", want 2025-07-07
```

The last green Renovate PR (#61) merged 22 June 2026; #63 ran 8 July. Nothing changed but the calendar. Because CI only runs `on: pull_request`, `main` has no runs of its own, which made this look like Renovate's fault — in fact *every* PR opened after 1 July fails.

## The fix

**Pin the clock for E2E runs.** Date-dependent server code now reads `internal/clock.Now()` instead of `time.Now()`. Both sides are pinned to a fixed date (`2026-03-24`):

- in-process E2E server pins `clock.Now` directly
- the Docker E2E container pins it via `WFH_TEST_TODAY` (test-only; the server logs a loud warning if it is ever set in production)
- the browser gets a `Date` shim installed before page scripts run, since the frontend derives the current FY from `new Date()`

Making the dates relative instead was the tempting cheaper option, but it doesn't hold: in early July the current FY has too few completed weeks to seed "three complete weeks then an incomplete one", so those tests would still fail for a fortnight every year.

## A real bug this surfaced

The four `WeekPicker` timeouts were not just stale test expectations — the picker is genuinely broken around the rollover:

1. **Blank sheet.** Between 1 July and the end of the new FY's first week there are no completed weeks to list, and the picker rendered an empty `<div>` with no message. It now says "No completed weeks yet this financial year".
2. **Picker and backend disagreed on where the FY starts.** The picker skipped the week straddling 1 July, but the backend requires entries for that week's July days and smart init opens it — so the picker would not list the very week it had just sent you to. It now lists that week and scores its completion on its in-FY days only, matching the backend's rule.

`TestE2E_WeekPicker_EmptyAtFYRollover` covers the rollover case by moving only the browser clock to 3 Jul 2026; it fails against the old frontend and passes with the fix.

## Verification

- `make check`, `make test-e2e` (33 tests), and `make test-e2e-docker` all pass locally — **on 13 July 2026**, a date on which `main` fails.
- Confirmed the container really honours the pin: it logs the warning, and its default report FY comes back as 2025 (last completed FY relative to the pinned date) rather than 2026.

Once this is on `main`, #63 should go green on rebase with its dependency bumps untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)