### PR TITLE
Re-subscribe from the service worker on pushsubscriptionchange

### DIFF
--- a/backend/e2e/sw_push_test.go
+++ b/backend/e2e/sw_push_test.go
@@ -1,0 +1,247 @@
+//go:build e2e || e2e_docker
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/go-rod/rod"
+)
+
+// swCall is one side effect the service worker performed while handling a
+// pushsubscriptionchange event: either a network request ("fetch") or a call to
+// pushManager.subscribe ("subscribe").
+type swCall struct {
+	Kind            string         `json:"kind"`
+	Method          string         `json:"method"`
+	URL             string         `json:"url"`
+	Body            map[string]any `json:"body"`
+	UserVisibleOnly bool           `json:"user_visible_only"`
+	Key             []int          `json:"key"`
+}
+
+// swResult is what the sandbox harness reports back after dispatching the event.
+type swResult struct {
+	Registered    bool     `json:"registered"`
+	WaitUntilArgs int      `json:"wait_until_args"`
+	Calls         []swCall `json:"calls"`
+}
+
+// The VAPID key the stubbed /api/notifications/vapid-key response hands back,
+// and the bytes urlBase64ToUint8Array must decode it to. "BQID" is URL-safe
+// base64 for the three bytes 0x05 0x02 0x03.
+const (
+	swVapidKey     = "BQID"
+	swNewEndpoint  = "https://push.example/new"
+	swOldEndpoint  = "https://push.example/old"
+	swNewP256dhKey = "new-p256dh"
+	swNewAuthKey   = "new-auth"
+)
+
+var swVapidKeyBytes = []int{5, 2, 3}
+
+// dispatchPushSubscriptionChange loads the deployed /sw.js, runs it in a sandbox
+// with stubbed service-worker globals, dispatches a pushsubscriptionchange event
+// at it, and reports everything the worker did in response.
+//
+// The real service worker cannot be driven from a test: Chrome will not create a
+// genuine push subscription without a push service, and there is no way to make
+// the browser fire pushsubscriptionchange on demand. Evaluating the shipped
+// source against fake globals exercises the worker's actual handler code, which
+// is the part this test is about.
+//
+// oldEndpoint is the endpoint on event.oldSubscription; pass "" to simulate a
+// browser that does not provide it.
+func dispatchPushSubscriptionChange(t *testing.T, page *rod.Page, oldEndpoint string) swResult {
+	t.Helper()
+
+	raw := page.MustEval(`async (oldEndpoint, vapidKey, newEndpoint, p256dh, auth) => {
+		const src = await (await fetch('/sw.js')).text();
+		const calls = [];
+
+		const fakeSub = {
+			endpoint: newEndpoint,
+			toJSON: () => ({ endpoint: newEndpoint, keys: { p256dh, auth } }),
+		};
+
+		const fakeSelf = {
+			listeners: {},
+			addEventListener(type, fn) {
+				(this.listeners[type] = this.listeners[type] || []).push(fn);
+			},
+			skipWaiting() {},
+			clients: { claim() {} },
+			registration: {
+				showNotification() {},
+				pushManager: {
+					subscribe(opts) {
+						calls.push({
+							kind: 'subscribe',
+							user_visible_only: !!opts.userVisibleOnly,
+							key: Array.from(opts.applicationServerKey || []),
+						});
+						return Promise.resolve(fakeSub);
+					},
+				},
+			},
+		};
+
+		const fakeCaches = {
+			open: () => Promise.resolve({ addAll: () => Promise.resolve() }),
+			keys: () => Promise.resolve([]),
+			match: () => Promise.resolve(undefined),
+			delete: () => Promise.resolve(true),
+		};
+
+		const fakeFetch = (url, opts) => {
+			opts = opts || {};
+			calls.push({
+				kind: 'fetch',
+				method: opts.method || 'GET',
+				url: String(url),
+				body: opts.body ? JSON.parse(opts.body) : null,
+			});
+			if (String(url).includes('vapid-key')) {
+				return Promise.resolve({
+					ok: true, status: 200,
+					json: () => Promise.resolve({ vapid_public_key: vapidKey }),
+				});
+			}
+			return Promise.resolve({
+				ok: true, status: 200,
+				json: () => Promise.resolve({ status: 'ok' }),
+			});
+		};
+
+		// The worker only calls self.addEventListener at the top level, so running
+		// it against fake globals is enough to collect its handlers.
+		new Function('self', 'caches', 'clients', 'fetch', src)(
+			fakeSelf, fakeCaches, fakeSelf.clients, fakeFetch);
+
+		const handlers = fakeSelf.listeners['pushsubscriptionchange'] || [];
+		if (handlers.length === 0) return { registered: false, wait_until_args: 0, calls };
+
+		const waited = [];
+		const event = {
+			waitUntil: p => waited.push(p),
+			oldSubscription: oldEndpoint ? { endpoint: oldEndpoint } : null,
+		};
+		handlers[0](event);
+		await Promise.all(waited);
+
+		return { registered: true, wait_until_args: waited.length, calls };
+	}`, oldEndpoint, swVapidKey, swNewEndpoint, swNewP256dhKey, swNewAuthKey)
+
+	encoded, err := json.Marshal(raw.Val())
+	if err != nil {
+		t.Fatalf("marshal harness result: %v", err)
+	}
+	var result swResult
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		t.Fatalf("decode harness result: %v", err)
+	}
+	return result
+}
+
+// findCall returns the first recorded call matching kind/method/url-substring.
+func findCall(calls []swCall, kind, method, urlPart string) *swCall {
+	for i := range calls {
+		c := calls[i]
+		if c.Kind != kind {
+			continue
+		}
+		if kind == "subscribe" {
+			return &calls[i]
+		}
+		if c.Method == method && strings.Contains(c.URL, urlPart) {
+			return &calls[i]
+		}
+	}
+	return nil
+}
+
+// TestE2E_SW_PushSubscriptionChange_ReSubscribes verifies that when the browser
+// invalidates a push subscription, the service worker fetches the VAPID key,
+// re-subscribes, registers the new subscription with the server, and deletes the
+// old endpoint.
+func TestE2E_SW_PushSubscriptionChange_ReSubscribes(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+
+	result := dispatchPushSubscriptionChange(t, page, swOldEndpoint)
+
+	if !result.Registered {
+		t.Fatal("sw.js does not register a pushsubscriptionchange listener")
+	}
+	if result.WaitUntilArgs != 1 {
+		t.Errorf("event.waitUntil calls: got %d, want 1 (the worker may be killed before it finishes)", result.WaitUntilArgs)
+	}
+
+	if c := findCall(result.Calls, "fetch", "GET", "/api/notifications/vapid-key"); c == nil {
+		t.Errorf("expected a GET of the VAPID key, got calls: %+v", result.Calls)
+	}
+
+	sub := findCall(result.Calls, "subscribe", "", "")
+	if sub == nil {
+		t.Fatalf("expected pushManager.subscribe to be called, got calls: %+v", result.Calls)
+	}
+	if !sub.UserVisibleOnly {
+		t.Error("pushManager.subscribe must be called with userVisibleOnly: true")
+	}
+	if len(sub.Key) != len(swVapidKeyBytes) {
+		t.Errorf("applicationServerKey: got %v, want the decoded VAPID key %v", sub.Key, swVapidKeyBytes)
+	} else {
+		for i, b := range swVapidKeyBytes {
+			if sub.Key[i] != b {
+				t.Errorf("applicationServerKey: got %v, want the decoded VAPID key %v", sub.Key, swVapidKeyBytes)
+				break
+			}
+		}
+	}
+
+	post := findCall(result.Calls, "fetch", "POST", "/api/notifications/subscribe")
+	if post == nil {
+		t.Fatalf("expected the new subscription to be POSTed, got calls: %+v", result.Calls)
+	}
+	if post.Body["endpoint"] != swNewEndpoint {
+		t.Errorf("POST endpoint: got %v, want %q", post.Body["endpoint"], swNewEndpoint)
+	}
+	if post.Body["p256dh_key"] != swNewP256dhKey {
+		t.Errorf("POST p256dh_key: got %v, want %q", post.Body["p256dh_key"], swNewP256dhKey)
+	}
+	if post.Body["auth_key"] != swNewAuthKey {
+		t.Errorf("POST auth_key: got %v, want %q", post.Body["auth_key"], swNewAuthKey)
+	}
+
+	del := findCall(result.Calls, "fetch", "DELETE", "/api/notifications/subscribe")
+	if del == nil {
+		t.Fatalf("expected the old endpoint to be DELETEd, got calls: %+v", result.Calls)
+	}
+	if del.Body["endpoint"] != swOldEndpoint {
+		t.Errorf("DELETE endpoint: got %v, want the old endpoint %q", del.Body["endpoint"], swOldEndpoint)
+	}
+}
+
+// TestE2E_SW_PushSubscriptionChange_NoOldSubscription verifies the worker still
+// re-subscribes when the browser gives no oldSubscription, and does not send a
+// DELETE with an empty endpoint (the server rejects that with 400).
+func TestE2E_SW_PushSubscriptionChange_NoOldSubscription(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+
+	result := dispatchPushSubscriptionChange(t, page, "")
+
+	if !result.Registered {
+		t.Fatal("sw.js does not register a pushsubscriptionchange listener")
+	}
+	if post := findCall(result.Calls, "fetch", "POST", "/api/notifications/subscribe"); post == nil {
+		t.Fatalf("expected the new subscription to be POSTed, got calls: %+v", result.Calls)
+	}
+	if del := findCall(result.Calls, "fetch", "DELETE", "/api/notifications/subscribe"); del != nil {
+		t.Errorf("no oldSubscription, so no DELETE should be sent; got %+v", *del)
+	}
+}

--- a/backend/internal/api/handlers/debug.go
+++ b/backend/internal/api/handlers/debug.go
@@ -8,13 +8,13 @@ import (
 
 // clientErrorReport is the payload sent by the browser's global error handler.
 type clientErrorReport struct {
-	Message     string `json:"message"`
-	Stack       string `json:"stack"`
-	URL         string `json:"url"`
-	Platform    string `json:"platform"`
-	DisplayMode string `json:"displayMode"`
-	ScreenWidth  int   `json:"screenWidth"`
-	ScreenHeight int   `json:"screenHeight"`
+	Message      string `json:"message"`
+	Stack        string `json:"stack"`
+	URL          string `json:"url"`
+	Platform     string `json:"platform"`
+	DisplayMode  string `json:"displayMode"`
+	ScreenWidth  int    `json:"screenWidth"`
+	ScreenHeight int    `json:"screenHeight"`
 }
 
 // PostClientError logs a client-side error report received from the browser.

--- a/docs/features.md
+++ b/docs/features.md
@@ -161,6 +161,7 @@ The application is installable as a PWA on supported browsers and devices:
 
 - `manifest.json` declares app name, display mode (`standalone`), theme colour, and icon
 - `sw.js` is a minimal service worker that caches the app shell (HTML, CSS, JS, manifest, icon) for fast subsequent loads; all `/api/` requests always go to the network
+- `sw.js` also handles the push events: `push` (show the notification), `notificationclick` (deep-link into the week), and `pushsubscriptionchange` (re-subscribe — see [Subscription lifecycle](#subscription-lifecycle)). It carries its own copy of `urlBase64ToUint8Array` because a service worker cannot import from `js/app.js`
 - An SVG app icon is provided at `icons/icon.svg`
 - On iOS, the `apple-touch-icon` link enables "Add to Home Screen" support
 - The browser's native install prompt is relied upon (no custom install UI)
@@ -313,6 +314,7 @@ The **Notifications** section appears in the Settings view:
 A Web Push subscription belongs to a specific browser/PWA install, not to the user. Uninstalling the PWA (or the browser discarding the subscription) invalidates it without informing the server, so the app keeps both ends in sync:
 
 - **Re-registration on startup**: whenever the app starts with notification permission granted and notifications enabled, it re-registers the current subscription with the server (creating a new one if the install no longer has one). A reinstalled PWA therefore registers its new endpoint the first time it is opened.
+- **Re-subscription on `pushsubscriptionchange`**: the browser fires this event at the service worker when it invalidates a subscription while the install is still in place (a key rotation, or a long stretch of inactivity). `sw.js` handles it by fetching the VAPID key, subscribing again, `POST`ing the new subscription, and `DELETE`ing `event.oldSubscription`'s endpoint if the browser supplied one. This complements the startup re-registration rather than replacing it — the event is not fired when the PWA is uninstalled, because the service worker goes with it, and Safari's support for it is incomplete. A failure here costs at most one missed notification: the next app start re-registers, and the server prunes the dead endpoint on the next failed send.
 - **Pruning of dead subscriptions**: when a push service reports a subscription as gone (HTTP `404` or `410` — Apple returns `410 Unregistered` after the PWA is uninstalled), the subscription is deleted from `push_subscriptions`. It is not treated as a retryable failure.
 - **Independent delivery per device**: a device that fails does not stop delivery to the user's other devices. A send is a failure only if no device accepted the notification.
 

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -57,3 +57,54 @@ self.addEventListener('notificationclick', e => {
   const url = weekStart ? `/?week=${weekStart}` : '/';
   e.waitUntil(clients.openWindow(url));
 });
+
+// The browser can invalidate a push subscription while the install is still in
+// place — a key rotation, or a long stretch of inactivity. It fires
+// pushsubscriptionchange when it does. Without this handler the server keeps
+// pushing to an endpoint the push service no longer recognises, and the user
+// silently receives nothing until the app next starts and re-registers.
+self.addEventListener('pushsubscriptionchange', e => {
+  e.waitUntil(resubscribe(e.oldSubscription));
+});
+
+// Creates a fresh push subscription and swaps it for the invalidated one on the
+// server. Errors reject the waitUntil promise: the app re-registers on its next
+// start, and the server prunes the dead endpoint the first time a send to it
+// fails, so a failure here costs at most a missed notification.
+async function resubscribe(oldSubscription) {
+  const { vapid_public_key: vapidKey } = await (await fetch('/api/notifications/vapid-key')).json();
+
+  const sub = await self.registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidKey),
+  });
+
+  const json = sub.toJSON();
+  await fetch('/api/notifications/subscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      endpoint:   json.endpoint,
+      p256dh_key: json.keys.p256dh,
+      auth_key:   json.keys.auth,
+    }),
+  });
+
+  // Not every browser supplies oldSubscription, so this is best-effort cleanup.
+  if (oldSubscription && oldSubscription.endpoint) {
+    await fetch('/api/notifications/subscribe', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint: oldSubscription.endpoint }),
+    });
+  }
+}
+
+// Converts a URL-safe base64 string to a Uint8Array for the Push API.
+// Duplicated from js/app.js — a service worker cannot import from the page.
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  return Uint8Array.from([...raw].map(c => c.charCodeAt(0)));
+}


### PR DESCRIPTION
Closes #68

## What

A browser can invalidate a push subscription while the PWA install is still in place — a key rotation, or a long idle period. Until now the server only learned about that when a send failed (and pruned the endpoint), or when the app next started and re-registered, so the user silently missed notifications in between.

`frontend/sw.js` now listens for `pushsubscriptionchange`. On receipt it fetches the VAPID key, re-subscribes with `userVisibleOnly: true`, `POST`s the new subscription, and `DELETE`s `event.oldSubscription`'s endpoint when the browser supplies one. The `DELETE` is skipped when it doesn't — the server rejects an empty endpoint with a 400, and prunes the dead endpoint on the next failed send regardless. The worker carries its own copy of `urlBase64ToUint8Array`, since a service worker cannot import from `js/app.js`.

This complements the startup re-registration rather than replacing it: the event is not fired when the PWA is uninstalled (the service worker goes with it).

## Tests

Driving a real service worker isn't possible — Chrome won't create a genuine push subscription without a push service, and there's no way to make it fire `pushsubscriptionchange` on demand. So `backend/e2e/sw_push_test.go` fetches the *deployed* `/sw.js` from the running server, runs it against fake service-worker globals (`self`, `caches`, `fetch`), dispatches the event at it, and asserts on what the handler actually did: the VAPID `GET`, the `subscribe` call and its decoded key bytes, the `POST` body, and the `DELETE` of the old endpoint. It also asserts `event.waitUntil` was called, since without it the browser can kill the worker mid-flight. A second test covers the no-`oldSubscription` case.

Both tests failed with "sw.js does not register a pushsubscriptionchange listener" before the change. Full unit and E2E suites pass.

## Notes

- The issue's open question — whether a fetch originating from the *real* service worker passes the forward-auth proxy — is **not** answered by this PR. The sandbox runs in the page context, so it can't test that. If the auth cookie isn't sent on SW-originated same-origin fetches, the re-registration silently 401s. It fails safe: the startup re-registration still covers it, and the server still prunes the dead endpoint.
- Safari's `pushsubscriptionchange` support is historically incomplete, so this may be a no-op on the iOS PWA that surfaced #66.
- `make check` runs `gofmt -w`, which reformatted pre-existing struct-tag misalignment in `backend/internal/api/handlers/debug.go`. Split into its own commit to keep the feature diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)