### PR TITLE
Fix racy assertion in the "Last week" week-picker E2E test

### DIFF
--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -749,17 +749,24 @@ func TestE2E_WeekPicker_LastWeekButton(t *testing.T) {
 	page.MustEval(`() => document.getElementById('jump-last-week').click()`)
 	waitFor(t, page, `() => document.getElementById('week-picker').open === false`)
 
-	// The diary should now show the previous week (relative to today)
-	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+	// Wait for the diary to actually re-render the previous week. Waiting on the
+	// row count alone races: seven rows are already on the page from the week we
+	// navigated in on, so the old rows can be read before the new week loads.
+	// Wait for the rows to belong to a different week instead.
+	waitFor(t, page, `() => {
+		const rows = document.querySelectorAll('#entry-tbody tr.day-row');
+		return rows.length === 7 && rows[0].dataset.date !== '2025-08-04';
+	}`)
 
-	// Just verify it navigated away from 2025-08-04
+	// The clock is pinned to e2eToday (Tue 24 Mar 2026), so "last week" is the
+	// week starting Mon 16 Mar 2026.
 	rows := page.MustElements("#entry-tbody tr.day-row")
 	firstDate, err := rows[0].Attribute("data-date")
 	if err != nil || firstDate == nil {
 		t.Fatal("could not read data-date from first row")
 	}
-	if *firstDate == "2025-08-04" {
-		t.Error("last week button should navigate away from current week")
+	if *firstDate != "2026-03-16" {
+		t.Errorf("after last week button: got %q, want 2026-03-16", *firstDate)
 	}
 }
 


### PR DESCRIPTION
## Why

`TestE2E_WeekPicker_LastWeekButton` has been failing in the "E2E tests" job on an unrelated Renovate PR (#70, setup-go v6 → v7). The failure is not caused by that PR, and it is not a financial-year rollover issue — the clock pinning added in d16f748 is working correctly, and this test's expected outcome is fully determined by that pin.

It's a race in the test itself:

```go
page.MustEval(`() => document.getElementById('jump-last-week').click()`)
waitFor(t, page, `... tr.day-row').length === 7`)   // already true
rows := page.MustElements("#entry-tbody tr.day-row")  // reads the OLD week
```

`jumpLastWeek()` calls `loadWeek()`, which `await`s `api.getEntries(...)` **before** clearing and rebuilding `#entry-tbody`. The seven rows from `?week=2025-08-04` are still on the page when the row-count predicate runs, so the assertion reads the stale `data-date`. Passing came down to whether the fetch beat the CDP round-trip — hence green on 13 July and red on 19 July with no code change in between.

This exact bug was already found and fixed in the neighbouring `TestE2E_WeekPicker_SelectWeek`; `LastWeekButton` was missed.

## What changed

- Wait for the rows to belong to a *different* week, matching the guard `SelectWeek` already uses.
- Assert the exact destination date. The clock is pinned to `e2eToday` (Tue 24 Mar 2026), so "last week" is always the week starting `2026-03-16`. The old check only verified the view had moved off `2025-08-04`, which a wrong-but-different week would have passed.

## Verification

- Before: failed 10/10 in isolation on unmodified `main`.
- After: passes 10/10 in isolation; full E2E suite green (`ok ato-wfh-diary/e2e 28.100s`); `gofmt` clean.

Other navigation tests were checked — `TestE2E_WeekNavigation` waits on the week label, which `loadWeek()` updates synchronously before the `await`, so it is not exposed to this race.

No `docs/` update needed: test-harness correction only, no schema, feature, or behaviour change.

Once merged, re-running the checks on #70 should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)