### PR TITLE
Replace report entry list with a per-week table

### DIFF
--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -249,10 +249,13 @@ func openReportForFY(t *testing.T, page *rod.Page, fy int) {
 // straddles 1 July — and reports each week's submission status and WFH hours.
 func TestE2E_ReportListsAllWeeksOfFY(t *testing.T) {
 	serverURL := newE2EServer(t)
-	userID := getUserID(t, serverURL, "alice")
+	// The Docker suite shares one database and isolates tests by giving each its
+	// own user, so seeding has to target the same user the page authenticates as.
+	u := testUsername(t, "alice")
+	userID := getUserID(t, serverURL, u)
 
 	// A fully submitted WFH week in the past of FY2026 (today is 2026-03-24).
-	seedWeekEntriesTyped(t, serverURL, "alice", userID, "2026-03-16", "wfh", 8)
+	seedWeekEntriesTyped(t, serverURL, u, userID, "2026-03-16", "wfh", 8)
 
 	_, page := newPage(t, "alice")
 	page.MustNavigate(serverURL)

--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -59,8 +59,14 @@ func pinBrowserClock(t *testing.T, page *rod.Page, today string) {
 	}
 }
 
-// seedWeekEntries makes a direct API call to seed 7 entries for the given weekMonday (YYYY-MM-DD).
+// seedWeekEntries makes a direct API call to seed 7 office entries for the given weekMonday (YYYY-MM-DD).
 func seedWeekEntries(t *testing.T, serverURL, username string, userID int64, weekMonday string) {
+	t.Helper()
+	seedWeekEntriesTyped(t, serverURL, username, userID, weekMonday, "office", 0)
+}
+
+// seedWeekEntriesTyped seeds all 7 days of weekMonday with the given day type and hours.
+func seedWeekEntriesTyped(t *testing.T, serverURL, username string, userID int64, weekMonday, dayType string, hours float64) {
 	t.Helper()
 	// Parse weekMonday
 	base, err := time.Parse("2006-01-02", weekMonday)
@@ -71,8 +77,8 @@ func seedWeekEntries(t *testing.T, serverURL, username string, userID int64, wee
 	for i := 0; i < 7; i++ {
 		entries[i] = map[string]any{
 			"entry_date": base.AddDate(0, 0, i).Format("2006-01-02"),
-			"day_type":   "office",
-			"hours":      0,
+			"day_type":   dayType,
+			"hours":      hours,
 		}
 	}
 	body, _ := json.Marshal(entries)
@@ -215,6 +221,122 @@ func TestE2E_ReportShowsTotals(t *testing.T) {
 	total := page.MustElement("#report-total").MustText()
 	if total == "—" || total == "" {
 		t.Errorf("report total not updated, got %q", total)
+	}
+}
+
+// selectReportFY switches the report's financial year selector and triggers a reload.
+func selectReportFY(t *testing.T, page *rod.Page, fy int) {
+	t.Helper()
+	page.MustEval(fmt.Sprintf(`() => {
+		const s = document.getElementById('fy-select');
+		s.value = '%d';
+		s.dispatchEvent(new Event('change'));
+	}`, fy))
+}
+
+// openReportForFY navigates to the report view for the given financial year and
+// waits for the week table to render.
+func openReportForFY(t *testing.T, page *rod.Page, fy int) {
+	t.Helper()
+	page.MustElement("#nav-report").MustClick()
+	waitFor(t, page, `() => !document.getElementById('view-report').hidden`)
+	selectReportFY(t, page, fy)
+	waitFor(t, page, `() => document.querySelectorAll('#report-tbody tr.week-row').length > 0`)
+}
+
+// TestE2E_ReportListsAllWeeksOfFY verifies the report replaces the per-entry
+// list with one row per week of the financial year — including the week that
+// straddles 1 July — and reports each week's submission status and WFH hours.
+func TestE2E_ReportListsAllWeeksOfFY(t *testing.T) {
+	serverURL := newE2EServer(t)
+	userID := getUserID(t, serverURL, "alice")
+
+	// A fully submitted WFH week in the past of FY2026 (today is 2026-03-24).
+	seedWeekEntriesTyped(t, serverURL, "alice", userID, "2026-03-16", "wfh", 8)
+
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	openReportForFY(t, page, 2026)
+
+	// FY2026 starts Wed 1 Jul 2025, so the first listed week is Mon 30 Jun 2025.
+	first := page.MustEval(`() => document.querySelector('#report-tbody tr.week-row').dataset.weekStart`).Str()
+	if first != "2025-06-30" {
+		t.Errorf("first week row: got %q, want 2025-06-30", first)
+	}
+
+	// The FY ends Tue 30 Jun 2026, so the last listed week is Mon 29 Jun 2026.
+	last := page.MustEval(`() => [...document.querySelectorAll('#report-tbody tr.week-row')].at(-1).dataset.weekStart`).Str()
+	if last != "2026-06-29" {
+		t.Errorf("last week row: got %q, want 2026-06-29", last)
+	}
+
+	statusOf := func(week string) string {
+		return page.MustEval(fmt.Sprintf(
+			`() => document.querySelector('#report-tbody tr[data-week-start="%s"] .week-status').textContent.trim()`, week)).Str()
+	}
+	hoursOf := func(week string) string {
+		return page.MustEval(fmt.Sprintf(
+			`() => document.querySelector('#report-tbody tr[data-week-start="%s"] .week-hours').textContent.trim()`, week)).Str()
+	}
+
+	if got := statusOf("2026-03-16"); got != "Submitted" {
+		t.Errorf("status of seeded week: got %q, want Submitted", got)
+	}
+	if got := hoursOf("2026-03-16"); got != "56.00" {
+		t.Errorf("hours of seeded week: got %q, want 56.00", got)
+	}
+
+	// A past week with no entries is unsubmitted and shows no hours.
+	if got := statusOf("2026-03-02"); got != "Unsubmitted" {
+		t.Errorf("status of empty past week: got %q, want Unsubmitted", got)
+	}
+	if got := hoursOf("2026-03-02"); got == "56.00" {
+		t.Errorf("empty past week should not report hours, got %q", got)
+	}
+
+	// A week that has not started yet is in the future.
+	if got := statusOf("2026-03-30"); got != "Future" {
+		t.Errorf("status of future week: got %q, want Future", got)
+	}
+}
+
+// TestE2E_ReportWeekOpensInDiary verifies clicking a week in the report opens
+// that week in the diary view for editing.
+func TestE2E_ReportWeekOpensInDiary(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	openReportForFY(t, page, 2026)
+
+	page.MustElement(`#report-tbody tr[data-week-start="2026-03-16"]`).MustClick()
+
+	waitFor(t, page, `() => !document.getElementById('view-diary').hidden`)
+	waitFor(t, page, `() => document.querySelector('#entry-tbody tr.day-row')?.dataset.date === '2026-03-16'`)
+}
+
+// TestE2E_ReportActionsAboveTable verifies the export/print buttons sit above
+// the week table rather than below it.
+func TestE2E_ReportActionsAboveTable(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	page.MustElement("#nav-report").MustClick()
+	waitFor(t, page, `() => !document.getElementById('view-report').hidden`)
+
+	// DOCUMENT_POSITION_FOLLOWING (4) means the table comes after the actions.
+	before := page.MustEval(`() => {
+		const actions = document.querySelector('.report-actions');
+		const table = document.getElementById('report-table');
+		return !!(actions.compareDocumentPosition(table) & Node.DOCUMENT_POSITION_FOLLOWING);
+	}`).Bool()
+	if !before {
+		t.Error("report actions should appear above the week table")
 	}
 }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -271,9 +271,30 @@ After successfully saving a week that is before the current week, the app automa
 
 - **Financial year selector** defaults to the most recently completed FY; up to 6 years are available
 - A **summary block** shows the selected user's name, financial year range, and total WFH hours
-- A **detail table** lists every WFH entry (date, type, hours, notes)
 - **Export CSV** downloads the report as a CSV file via the backend export endpoint
 - **Print PDF** opens a print dialog with a formatted A4 calendar view of the full financial year (see Print PDF section above)
+- The Export CSV / Print PDF buttons sit directly below the summary block, above the week table
+- A **week table** lists every week of the financial year (see below)
+
+##### Week table
+
+A per-entry list of every WFH day was too long to scan and duplicated the CSV/PDF exports. The table instead shows one row per week, so the useful question — which weeks are still to be filled in — is answerable at a glance.
+
+| Column | Description |
+|---|---|
+| **Week starting** | The Monday of the week. The first row is the week **containing 1 July**, so a FY starting mid-week lists a Monday in June; the last row is the week containing 30 June. |
+| **Status** | `Submitted`, `Unsubmitted`, or `Future` |
+| **WFH Hours** | Total `wfh` + `part_wfh` hours for the week; shown only for submitted weeks (`—` otherwise) |
+
+Status is derived as:
+
+- **Submitted** — the week has an entry for every one of its days that falls **inside the FY**. The weeks straddling 1 July and 30 June therefore need only their in-FY days, matching the rule used by the week picker and the `first-incomplete-week` API.
+- **Future** — not submitted, and the week's Monday is after today. The current week is never `Future`.
+- **Unsubmitted** — everything else.
+
+Clicking (or pressing Enter/Space on) a week row opens that week in the **Diary** view for editing. Rows are focusable via the keyboard.
+
+All of this is computed client-side from the `all_entries` array already returned by `GET /api/users/{id}/report` — no additional request is made.
 
 ## Push Notifications
 

--- a/frontend/css/app.css
+++ b/frontend/css/app.css
@@ -142,7 +142,26 @@
 
 #report-summary p { margin: 0; }
 
-#export-csv { width: auto; margin-top: 1rem; }
+.report-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.report-actions button { width: auto; margin: 0; }
+
+/* Week rows in the report link through to the diary, so make them feel
+   clickable and keep the keyboard focus ring visible. */
+.week-row { cursor: pointer; }
+
+.week-row:hover,
+.week-row:focus-visible {
+  background: var(--pico-secondary-background, #eee);
+}
+
+.week-status.submitted   { color: var(--pico-color-green-550,  #2e7d32); }
+.week-status.unsubmitted { color: var(--pico-color-red-550,    #c62828); }
+.week-status.future      { color: var(--pico-muted-color,      #777);    }
 
 .empty-msg {
   text-align: center;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -101,14 +101,17 @@
         <select id="fy-select"></select>
       </div>
       <div id="report-summary"></div>
+      <div class="report-actions">
+        <button id="export-csv" class="secondary">Export CSV</button>
+        <button id="print-pdf" class="secondary">Print PDF</button>
+      </div>
       <div class="table-wrapper">
         <table id="report-table">
           <thead>
             <tr>
-              <th>Date</th>
-              <th>Type</th>
-              <th>Hours</th>
-              <th>Notes</th>
+              <th>Week starting</th>
+              <th>Status</th>
+              <th>WFH Hours</th>
             </tr>
           </thead>
           <tbody id="report-tbody"></tbody>
@@ -116,14 +119,9 @@
             <tr>
               <td colspan="2"><strong>Total WFH Hours</strong></td>
               <td id="report-total"><strong>&#8212;</strong></td>
-              <td></td>
             </tr>
           </tfoot>
         </table>
-      </div>
-      <div class="report-actions">
-        <button id="export-csv" class="secondary">Export CSV</button>
-        <button id="print-pdf" class="secondary">Print PDF</button>
       </div>
     </section>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -38,21 +38,34 @@ const defaultFY    = () => currentFY() - 1;
 // requiredDays returns how many days of the week beginning on monday fall inside
 // the financial year beginning on fyStart. A week straddling 1 July only needs
 // its in-FY days filled in to count as complete, which is the same rule the
-// backend applies when it looks for the first incomplete week.
-const requiredDays = (monday, fyStart) => {
+// backend applies when it looks for the first incomplete week. fyEnd (30 June)
+// clamps the other end for the week straddling the close of the FY; it is
+// optional because the week picker only ever lists weeks in the current FY.
+const requiredDays = (monday, fyStart, fyEnd = null) => {
   const from   = monday < fyStart ? fyStart : monday;
   const sunday = addDays(monday, 6);
-  return Math.round((sunday - from) / 86400000) + 1;
+  const to     = fyEnd && sunday > fyEnd ? fyEnd : sunday;
+  return Math.round((to - from) / 86400000) + 1;
 };
+
+// fyBounds returns the first and last day of the given financial year.
+const fyBounds = fy => ({ fyStart: new Date(fy - 1, 6, 1), fyEnd: new Date(fy, 5, 30) });
+
+// fyWeeks returns the Monday of every week that contains at least one day of
+// the financial year — including the weeks straddling 1 July and 30 June.
+function fyWeeks(fy) {
+  const { fyStart, fyEnd } = fyBounds(fy);
+  const weeks = [];
+  for (let mon = getMonday(fyStart); mon <= fyEnd; mon = addDays(mon, 7)) {
+    weeks.push(new Date(mon));
+  }
+  return weeks;
+}
 
 function fmtLabel(dateStr) {
   return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-AU', {
     weekday: 'short', day: 'numeric', month: 'short',
   });
-}
-
-function dayTypeLabel(t) {
-  return DAY_TYPES.find(d => d.value === t)?.label ?? t;
 }
 
 function escapeHTML(s) {
@@ -773,16 +786,7 @@ async function loadReport() {
       `FY${reportFY} (${reportFY - 1}&#8211;${reportFY}) &nbsp;&middot;&nbsp; ` +
       `Total WFH: <strong>${(+report.total_hours).toFixed(2)} hours</strong></p>`;
 
-    const rows = report.entries ?? [];
-    document.getElementById('report-tbody').innerHTML = rows.length === 0
-      ? '<tr><td colspan="4" class="empty-msg">No WFH entries for this financial year.</td></tr>'
-      : rows.map(e => `
-          <tr>
-            <td>${e.entry_date}</td>
-            <td>${dayTypeLabel(e.day_type)}</td>
-            <td>${(+e.hours).toFixed(2)}</td>
-            <td>${escapeHTML(e.notes ?? '')}</td>
-          </tr>`).join('');
+    renderReportWeeks(report);
 
     document.getElementById('report-total').innerHTML =
       `<strong>${(+report.total_hours).toFixed(2)}</strong>`;
@@ -790,6 +794,63 @@ async function loadReport() {
     document.getElementById('report-summary').innerHTML =
       `<p class="error">${escapeHTML(e.message)}</p>`;
   }
+}
+
+// renderReportWeeks fills the report table with one row per week of the
+// financial year. A per-entry list was too long to be useful — what matters
+// when preparing a return is which weeks are still missing, so each row shows
+// the week's submission status and its WFH total, and clicking it opens that
+// week in the diary for editing.
+function renderReportWeeks(report) {
+  const fy = report.financial_year ?? reportFY;
+  const { fyStart, fyEnd } = fyBounds(fy);
+
+  // Bucket the FY's entries by the Monday of the week they fall in.
+  const byWeek = {};
+  (report.all_entries ?? []).forEach(e => {
+    const key = formatDate(getMonday(new Date(e.entry_date + 'T00:00:00')));
+    const w = byWeek[key] ?? (byWeek[key] = { count: 0, hours: 0 });
+    w.count++;
+    if (isWFH(e.day_type)) w.hours += +e.hours;
+  });
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const tbody = document.getElementById('report-tbody');
+  tbody.innerHTML = fyWeeks(fy).map(mon => {
+    const ws = formatDate(mon);
+    const week = byWeek[ws] ?? { count: 0, hours: 0 };
+    const submitted = week.count >= requiredDays(mon, fyStart, fyEnd);
+
+    let status, cls;
+    if (submitted)        { status = 'Submitted';   cls = 'submitted'; }
+    else if (mon > today) { status = 'Future';      cls = 'future';    }
+    else                  { status = 'Unsubmitted'; cls = 'unsubmitted'; }
+
+    // Hours are only meaningful once the week has been filled in.
+    const hours = submitted ? week.hours.toFixed(2) : '&#8212;';
+
+    return `<tr class="week-row" data-week-start="${ws}" tabindex="0">
+      <td>${fmtLabel(ws)} ${mon.getFullYear()}</td>
+      <td class="week-status ${cls}">${status}</td>
+      <td class="week-hours">${hours}</td>
+    </tr>`;
+  }).join('');
+
+  tbody.querySelectorAll('.week-row').forEach(row => {
+    const open = () => openWeekInDiary(row.dataset.weekStart);
+    row.addEventListener('click', open);
+    row.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+    });
+  });
+}
+
+// openWeekInDiary switches to the diary view showing the given week.
+function openWeekInDiary(weekStartStr) {
+  weekStart = getMonday(new Date(weekStartStr + 'T00:00:00'));
+  showView('diary');
 }
 
 // ── PDF / Print ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #73

## What

The report view listed every WFH entry for the financial year — a long scroll that duplicated what the CSV and PDF exports already provide, and never answered the question actually being asked: which weeks still need filling in.

Each row is now one week of the FY:

| Column | Description |
|---|---|
| **Week starting** | The Monday of the week |
| **Status** | `Submitted` / `Unsubmitted` / `Future` |
| **WFH Hours** | Week total, shown for submitted weeks (`—` otherwise) |

Clicking (or pressing Enter/Space on) a row opens that week in the **Diary** view for editing. Export CSV / Print PDF have moved above the table, directly below the summary.

## Notes

- The list spans the whole FY including the weeks straddling **1 July** and **30 June**. Those count as submitted once their in-FY days are filled — the same rule the week picker and the `first-incomplete-week` API apply. `requiredDays()` gained an optional `fyEnd` clamp for the closing week.
- A week is `Future` only when its Monday is after today, so the current, partly-unfinished week reads as `Unsubmitted`.
- Everything is derived client-side from the report's existing `all_entries` array — **no API change**.

## Testing

Written TDD — the three new E2E tests failed first (no `.week-row`, actions below the table), then passed.

- `TestE2E_ReportListsAllWeeksOfFY` — FY boundaries (first row `2025-06-30`, last `2026-06-29`) and all three statuses
- `TestE2E_ReportWeekOpensInDiary` — click-through to the diary on the right week
- `TestE2E_ReportActionsAboveTable` — button placement

`make check` and the full `make test-e2e` (38 tests) pass.

Docs updated in `docs/features.md` per the project's documentation policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)