### PR TITLE
Don't change weeks on save

### DIFF
--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -165,7 +165,7 @@ func TestE2E_SaveAndReloadEntry(t *testing.T) {
 	firstRow.MustElement(".day-type-select").MustSelect("Work From Home")
 	firstRow.MustElement(".hours-input").MustInput("7.5")
 
-	// Save (current week, so no auto-advance).
+	// Save.
 	page.MustElement("#save-entries").MustClick()
 	waitFor(t, page, `() => document.getElementById('save-status').textContent === 'Saved'`)
 
@@ -664,18 +664,19 @@ func TestE2E_SmartInit_FallsBackToCurrentWeek(t *testing.T) {
 	}
 }
 
-// TestE2E_AutoAdvance_AfterSavingPastWeek verifies that after saving a past
-// week the app automatically advances to the next incomplete week.
-func TestE2E_AutoAdvance_AfterSavingPastWeek(t *testing.T) {
+// TestE2E_SavePastWeek_StaysOnWeek verifies that saving a past week leaves the
+// user on that same week rather than navigating elsewhere (issue #75).
+func TestE2E_SavePastWeek_StaysOnWeek(t *testing.T) {
 	serverURL := newE2EServer(t)
 	_, page := newPage(t, "alice")
 
 	u := testUsername(t, "alice")
 	userID := getUserID(t, serverURL, u)
-	// Seed 2025-07-14 as complete; leave 2025-07-07 and 2025-07-21 empty.
+	// Seed 2025-07-14 as complete; leave 2025-07-07 and 2025-07-21 empty, so
+	// the old auto-advance behaviour would have jumped to 2025-07-21.
 	seedWeekEntries(t, serverURL, u, userID, "2025-07-14")
 
-	// Navigate directly to the first incomplete week (2025-07-07)
+	// Navigate directly to a past week (2025-07-07)
 	page.MustNavigate(serverURL + "?week=2025-07-07")
 	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
 
@@ -688,17 +689,21 @@ func TestE2E_AutoAdvance_AfterSavingPastWeek(t *testing.T) {
 	page.MustElement("#save-entries").MustClick()
 	waitFor(t, page, `() => document.getElementById('save-status').textContent === 'Saved'`)
 
-	// After saving a past week, app should advance to the next incomplete week.
-	// 2025-07-14 is complete, so next incomplete is 2025-07-21.
+	// Give any (unwanted) navigation a chance to happen before asserting.
 	time.Sleep(800 * time.Millisecond)
 
 	rows := page.MustElements("#entry-tbody tr.day-row")
 	firstDate, err := rows[0].Attribute("data-date")
 	if err != nil || firstDate == nil {
-		t.Fatal("could not read data-date from first row after auto-advance")
+		t.Fatal("could not read data-date from first row after save")
 	}
-	if *firstDate != "2025-07-21" {
-		t.Errorf("auto-advance: first row date got %q, want 2025-07-21", *firstDate)
+	if *firstDate != "2025-07-07" {
+		t.Errorf("save navigated away: first row date got %q, want 2025-07-07", *firstDate)
+	}
+
+	status := page.MustElement("#week-status").MustText()
+	if !strings.Contains(status, "Saved") {
+		t.Errorf("week-status got %q, want it to contain \"Saved\"", status)
 	}
 }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -252,9 +252,9 @@ On app load (without a `?week=` query parameter), instead of always showing the 
 - Weeks are checked from the first Monday on or after July 1 of the current FY up to and including the current week's Monday; future weeks are not checked
 - The existing `?week=YYYY-MM-DD` URL query parameter still takes precedence over this logic
 
-#### Auto-Advance After Saving a Past Week
+#### Saving Stays on the Current Week
 
-After successfully saving a week that is before the current week, the app automatically advances to the **next incomplete week** (i.e. calls the API with `from_date = savedWeek + 7 days`). If no incomplete week is found from that point, it navigates to the current week. Saving the current week retains existing behaviour (stay on the current week).
+Saving never navigates away from the week being edited. After a successful save the app shows a "✓ Saved" confirmation and stays put; the user moves between weeks using the week navigation controls.
 
 #### Settings
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -413,25 +413,10 @@ async function saveWeek() {
     return entry;
   });
 
-  const savedWeekStart = weekStart;
-
   try {
     await api.saveEntries(selectedUserId, entries);
 
-    // Auto-advance: if the saved week is before the current week, navigate
-    // to the next incomplete week (or fall back to the current week).
-    const currentMonday = getMonday(new Date());
-    if (savedWeekStart < currentMonday) {
-      const nextFromDate = formatDate(addDays(savedWeekStart, 7));
-      const fy = currentFY();
-      const data = await api.getFirstIncompleteWeek(selectedUserId, fy, nextFromDate).catch(() => null);
-      if (data?.week_start) {
-        weekStart = getMonday(new Date(data.week_start + 'T00:00:00'));
-      } else {
-        weekStart = currentMonday;
-      }
-      await loadWeek({ keepStatus: true });
-    }
+    // Stay on the saved week — the user navigates weeks themselves.
 
     // Scroll to top so the user sees the week heading and the Saved confirmation.
     window.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
Fixes #75

## Problem

After saving a week in the diary view, the page jumped forward to another week — the next incomplete week, or the current week as a fallback. Users could easily end up entering data against the wrong week without noticing.

## Change

- **`frontend/js/app.js`** — removed the auto-advance block from `saveWeek()`. Saving now persists the entries, scrolls to the top, and shows the `✓ Saved` confirmation, leaving the user on the week they were editing. Week navigation is entirely manual.
- The `first-incomplete-week` API is **unchanged** — it's still used by the smart initial load and the "First incomplete" button.
- **`docs/features.md`** — replaced the "Auto-Advance After Saving a Past Week" section with one describing the new stay-put behaviour.

## Tests

Written TDD-first. `TestE2E_AutoAdvance_AfterSavingPastWeek` is replaced by `TestE2E_SavePastWeek_StaysOnWeek`, which seeds the same fixture the old test used (so the old behaviour *would* have advanced to 2025-07-21), saves a past week, then asserts the first row's `data-date` is still `2025-07-07` and that `#week-status` shows the saved confirmation.

The new test failed before the fix with `save navigated away: first row date got "2025-07-21", want 2025-07-07`, and passes after. Full unit suite and the complete e2e suite are green.

Also dropped a now-stale `// Save (current week, so no auto-advance).` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)