### PR TITLE
Refresh week status after saving a week

### DIFF
--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -241,7 +241,12 @@ func openReportForFY(t *testing.T, page *rod.Page, fy int) {
 	page.MustElement("#nav-report").MustClick()
 	waitFor(t, page, `() => !document.getElementById('view-report').hidden`)
 	selectReportFY(t, page, fy)
-	waitFor(t, page, `() => document.querySelectorAll('#report-tbody tr.week-row').length > 0`)
+	// Wait for the requested FY's rows specifically. Navigating to the report
+	// kicks off a load for the default FY, so "any rows present" can be
+	// satisfied by that year's table while the switch is still in flight.
+	waitFor(t, page, fmt.Sprintf(
+		`() => document.getElementById('report-tbody').dataset.fy === '%d'
+			&& document.querySelectorAll('#report-tbody tr.week-row').length > 0`, fy))
 }
 
 // TestE2E_ReportListsAllWeeksOfFY verifies the report replaces the per-entry
@@ -302,6 +307,49 @@ func TestE2E_ReportListsAllWeeksOfFY(t *testing.T) {
 	// A week that has not started yet is in the future.
 	if got := statusOf("2026-03-30"); got != "Future" {
 		t.Errorf("status of future week: got %q, want Future", got)
+	}
+}
+
+// TestE2E_ReportStaleLoadDoesNotOverwrite verifies that switching financial
+// year while the previous year's report is still loading leaves the requested
+// year on screen. Opening the report starts a load for the default FY, so a
+// slow response for that year must not repaint over the FY the user picked.
+func TestE2E_ReportStaleLoadDoesNotOverwrite(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+	page.MustNavigate(serverURL)
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	// Delay only the first report request (the default FY) by 1.5s, so it is
+	// guaranteed to land after the FY2026 request that follows it.
+	page.MustEval(`() => {
+		const realFetch = window.fetch;
+		let delayed = false;
+		window.fetch = (url, ...rest) => {
+			if (typeof url === 'string' && url.includes('/report?financial_year=') && !delayed) {
+				delayed = true;
+				return new Promise(resolve =>
+					setTimeout(() => resolve(realFetch(url, ...rest)), 1500));
+			}
+			return realFetch(url, ...rest);
+		};
+	}`)
+
+	page.MustElement("#nav-report").MustClick()
+	waitFor(t, page, `() => !document.getElementById('view-report').hidden`)
+	selectReportFY(t, page, 2026)
+
+	// Wait past the delayed response so any overwrite would have happened.
+	waitFor(t, page, `() => document.getElementById('report-tbody').dataset.fy === '2026'`)
+	time.Sleep(2 * time.Second)
+
+	fy := page.MustEval(`() => document.getElementById('report-tbody').dataset.fy`).Str()
+	if fy != "2026" {
+		t.Errorf("report table FY after stale load: got %q, want 2026", fy)
+	}
+	first := page.MustEval(`() => document.querySelector('#report-tbody tr.week-row').dataset.weekStart`).Str()
+	if first != "2025-06-30" {
+		t.Errorf("first week row after stale load: got %q, want 2025-06-30", first)
 	}
 }
 

--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -707,6 +707,35 @@ func TestE2E_SavePastWeek_StaysOnWeek(t *testing.T) {
 	}
 }
 
+// TestE2E_SaveWeek_StatusBecomesSubmitted verifies that after saving a full
+// week, once the transient "Saved" message clears the week-status indicator
+// reflects the newly submitted week rather than reverting to "not submitted"
+// (issue #77).
+func TestE2E_SaveWeek_StatusBecomesSubmitted(t *testing.T) {
+	serverURL := newE2EServer(t)
+	_, page := newPage(t, "alice")
+
+	// Start on an empty week, so the indicator begins as "not submitted".
+	page.MustNavigate(serverURL + "?week=2025-07-07")
+	waitFor(t, page, `() => document.querySelectorAll('#entry-tbody tr.day-row').length === 7`)
+
+	page.MustEval(`() => {
+		document.querySelectorAll('#entry-tbody tr.day-row').forEach(row => {
+			row.querySelector('.day-type-select').value = 'office';
+		});
+	}`)
+	page.MustElement("#save-entries").MustClick()
+	waitFor(t, page, `() => document.getElementById('save-status').textContent === 'Saved'`)
+
+	// The "Saved" confirmation clears after 3s; wait for it to go away.
+	waitFor(t, page, `() => document.getElementById('save-status').textContent === ''`)
+
+	status := page.MustElement("#week-status").MustText()
+	if strings.Contains(status, "not submitted") {
+		t.Errorf("week-status after save got %q, want it to show the week as submitted", status)
+	}
+}
+
 // TestE2E_WeekPicker_OpensAndCloses verifies that tapping the week label
 // opens the week picker bottom sheet and that it can be closed.
 func TestE2E_WeekPicker_OpensAndCloses(t *testing.T) {

--- a/docs/features.md
+++ b/docs/features.md
@@ -297,6 +297,8 @@ Clicking (or pressing Enter/Space on) a week row opens that week in the **Diary*
 
 All of this is computed client-side from the `all_entries` array already returned by `GET /api/users/{id}/report` — no additional request is made.
 
+Changing the financial year while a report is still loading leaves two requests in flight, and they can complete out of order. Each load is tagged with a sequence number and a response is discarded if a newer load has started since, so a slow response for the previous year cannot repaint over the year the user selected. The rendered year is exposed as `data-fy` on `#report-tbody`.
+
 ## Push Notifications
 
 Users who have installed the app as a PWA can opt in to weekly reminders to fill in their hours.

--- a/docs/features.md
+++ b/docs/features.md
@@ -199,6 +199,7 @@ The fetch handler chooses a strategy per request:
   - 🔴 **"Week not submitted"** — fewer than 7 entries exist for the displayed week
   - 🟢 **"Week submitted"** — all 7 entries are present for the displayed week
   - The indicator is updated on every `loadWeek()` call using the entry count returned by the existing `getEntries` API — no additional request is needed
+  - On save, the indicator temporarily shows "✓ Saved"; once that confirmation clears (after 3 seconds) it reflects the **newly saved** week. Because Save Week always submits all 7 rows, a saved week is always shown as submitted — no re-fetch is required
 
 #### Week Picker
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -765,10 +765,18 @@ function clearProfileStatus() {
 }
 
 // ── Report ─────────────────────────────────────────────────────────────────
+// reportLoadSeq tags each in-flight report fetch. Switching financial year
+// while a load is still running leaves two requests racing, and responses can
+// arrive out of order — without this guard a slow response for the previous FY
+// repaints the table over the FY the user actually asked for.
+let reportLoadSeq = 0;
+
 async function loadReport() {
+  const seq = ++reportLoadSeq;
   try {
-    currentReport = await api.getReport(selectedUserId, reportFY);
-    const report = currentReport;
+    const report = await api.getReport(selectedUserId, reportFY);
+    if (seq !== reportLoadSeq) return; // superseded by a newer load
+    currentReport = report;
 
     document.getElementById('report-summary').innerHTML =
       `<p><strong>${escapeHTML(report.display_name)}</strong> &nbsp;&middot;&nbsp; ` +
@@ -780,6 +788,7 @@ async function loadReport() {
     document.getElementById('report-total').innerHTML =
       `<strong>${(+report.total_hours).toFixed(2)}</strong>`;
   } catch (e) {
+    if (seq !== reportLoadSeq) return; // superseded by a newer load
     document.getElementById('report-summary').innerHTML =
       `<p class="error">${escapeHTML(e.message)}</p>`;
   }
@@ -807,6 +816,9 @@ function renderReportWeeks(report) {
   today.setHours(0, 0, 0, 0);
 
   const tbody = document.getElementById('report-tbody');
+  // Record which FY these rows belong to, so a caller can tell a finished
+  // switch from rows still left over from the previously selected year.
+  tbody.dataset.fy = fy;
   tbody.innerHTML = fyWeeks(fy).map(mon => {
     const ws = formatDate(mon);
     const week = byWeek[ws] ?? { count: 0, hours: 0 };

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -418,6 +418,10 @@ async function saveWeek() {
 
     // Stay on the saved week — the user navigates weeks themselves.
 
+    // The week now holds exactly what we just posted, so keep the tracked count
+    // in sync; otherwise clearStatus() would restore a stale "not submitted".
+    weekEntryCount = entries.length;
+
     // Scroll to top so the user sees the week heading and the Saved confirmation.
     window.scrollTo({ top: 0, behavior: 'smooth' });
 


### PR DESCRIPTION
Fixes #77

## 1. Week status after saving (the reported bug)

After saving a week, the status bar shows "✓ Saved" for three seconds. When that cleared, the indicator reverted to 🔴 "Week not submitted" — even though the week had just been submitted.

`clearStatus()` restores the indicator via `renderWeekStatus(weekEntryCount)`, but `weekEntryCount` was only ever assigned in `loadWeek()`. Before #75, saving reloaded/advanced the week, which incidentally refreshed the count. Now that save deliberately stays put, nothing updated it — so `clearStatus()` replayed the stale pre-save count (0 for a fresh week).

Fix is one line in `saveWeek()`:

```js
weekEntryCount = entries.length;
```

Chosen over a re-fetch because `saveWeek` always submits all 7 day rows and the backend upserts exactly what it receives (`db/entries.go:12`), so the local count already matches what a reload would return. It also avoids re-running `loadWeek()`, which would replay the week-label flash animation and misleadingly suggest the week had changed.

Covered by `TestE2E_SaveWeek_StatusBecomesSubmitted`, which waits for the "Saved" text to clear rather than sleeping a fixed interval. Confirmed failing before the fix:

```
week-status after save got "🔴 Week not submitted", ...
```

## 2. Superseded report loads (surfaced by CI)

The first CI run failed in `TestE2E_ReportListsAllWeeksOfFY`, listing FY2025 weeks where FY2026 was requested. Unrelated to the fix above — a pre-existing race this PR happened to expose.

Opening the report starts a load for the default FY; selecting a different year starts a second load while the first is in flight. Responses render as they arrive and `renderReportWeeks` renders whatever year the response carries, so on a slow runner the FY2025 response landed last and repainted over FY2026. This is user-facing, not just a test artifact: changing the FY dropdown quickly could leave you looking at the wrong year's data.

Two changes:
- `loadReport()` tags each load with a sequence number and discards any response superseded by a newer load.
- `renderReportWeeks` exposes the rendered year as `data-fy` on `#report-tbody`. The test helper now waits on that instead of "any rows present" — which the stale table already satisfied, so it never actually waited for the year switch.

`TestE2E_ReportStaleLoadDoesNotOverwrite` forces the bad ordering by delaying the first report response by 1.5s. With the guard removed it fails with `got "2024-07-01", want 2025-06-30` — identical to the original CI failure.

## Testing

All three CI jobs pass. Docs updated per the documentation policy in CLAUDE.md.

## Note for review

The fix means *any* save marks the week submitted, since the UI always posts 7 rows with defaulted day types. That's self-consistent — navigating away and back shows the same thing — but "submitted" effectively tracks "has this week been saved" rather than "has the user reviewed every day". A stricter notion would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)